### PR TITLE
Require dataclasses package for python 3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 from setuptools import setup, find_packages
+import sys
 
 setup_requirements = []
 
@@ -8,6 +9,8 @@ requirements = [
     "fsspec>=0.6.0",
     "zarr>=2.3.2",
 ]
+if sys.version_info.major == 3 and sys.version_info.minor == 6:
+    requirements.append("dataclasses")
 
 test_requirements = []
 


### PR DESCRIPTION
This PR adds code to setup.py to require the dataclasses backport package, only for python 3.6.