### PR TITLE
Allow symlinked optional restarts to be read

### DIFF
--- a/fv3gfs/util/_legacy_restart.py
+++ b/fv3gfs/util/_legacy_restart.py
@@ -77,7 +77,7 @@ def restart_filenames(dirname, tile_index, label):
     return_list = []
     for name in RESTART_NAMES + RESTART_OPTIONAL_NAMES:
         filename = os.path.join(dirname, prepend_label(name, label) + suffix)
-        if (name in RESTART_NAMES) or filesystem.is_file(filename):
+        if (name in RESTART_NAMES) or os.path.exists(filename):
             return_list.append(filename)
     return return_list
 


### PR DESCRIPTION
This fixes an issue where symlinked restart files (such as those in the fv3net prognostic run nudged regression test) were not read because `filesystem.isfile(symlink) = False`. `os.path.exists` works on symlink targets. This loses the check on whether it's a file, but that's sort of implicit in the `*.nc` names we are checking for.
 