### PR TITLE
added managed_memory to kwargs in wrapped_storage

### DIFF
--- a/fv3gfs/util/initialization/allocator.py
+++ b/fv3gfs/util/initialization/allocator.py
@@ -10,6 +10,7 @@ except ImportError:
 
 def _wrap_storage_call(function, backend):
     def wrapped(shape, dtype=float, **kwargs):
+        kwargs["managed_memory"] = True
         return function(backend, [0] * len(shape), shape, dtype, **kwargs)
 
     wrapped.__name__ = function.__name__


### PR DESCRIPTION
The data field in the Quantity class uses an explicitly managed gt_storage object for data.  When allocating a new data field member using QuantityFactory, only CPUstorage and GPUstorage is currently recognized as managed_memory is set to False.  Setting this option to True will allow the use of ExplicitlyManagedGPUStorage as a data field type.