### PR TITLE
Restore filesystem.is_file check in restart_filenames

### DIFF
--- a/fv3gfs/util/_legacy_restart.py
+++ b/fv3gfs/util/_legacy_restart.py
@@ -77,7 +77,11 @@ def restart_filenames(dirname, tile_index, label):
     return_list = []
     for name in RESTART_NAMES + RESTART_OPTIONAL_NAMES:
         filename = os.path.join(dirname, prepend_label(name, label) + suffix)
-        if (name in RESTART_NAMES) or os.path.exists(filename):
+        if (
+            (name in RESTART_NAMES)
+            or filesystem.is_file(filename)
+            or os.path.exists(filename)
+        ):
             return_list.append(filename)
     return return_list
 


### PR DESCRIPTION
I ran into an issue where `open_restart` would not load `sfc_data` restart files if they were hosted on GCS.  I tracked it down to [this line](https://github.com/VulcanClimateModeling/fv3gfs-util/blob/master/fv3gfs/util/_legacy_restart.py#L80) (`sfc_data` restart files are considered optional, and when hosted remotely, `os.path.exists` would return `False`).

It seems like to support symlinks we definitely still need the `os.path.exists` pathway (#15) -- would it be OK to add back in the `filesystem.is_file` check to the `or` condition to support this use-case?