### PR TITLE
fix bug where quantity.view could become out of sync with data

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -21,6 +21,7 @@ in the `coupler_nml` namelist.
 
 Fixes:
 - Fixed a bug where quantity.storage and quantity.data could be out of sync if the quantity was initialized using data and a gt4py backend string
+- Fixed a bug where quantity.view could refer to a different array than quantity.data if the quantity was initialized using data and a gt4py backend string, and then quantity.storage was accessed
 
 v0.5.1
 ------

--- a/fv3gfs/util/quantity.py
+++ b/fv3gfs/util/quantity.py
@@ -383,14 +383,19 @@ class Quantity:
                 mask=None,
             )
             self._storage[...] = self._data
-            # storage must initialize new memory. when GDP-2 is merged, we can instead
+            # storage must initialize new memory. when GDP-3 is merged, we can instead
             # initialize storage from self._data
-            # when GDP-2 is merged, we can instead use the data in self._data to
+            # when GDP-3 is merged, we can instead use the data in self._data to
             # initialize the storage, instead of making a copy.
             if isinstance(self._data, np.ndarray):
                 self._data = self.np.asarray(self._storage.data)
             elif isinstance(self._data, cupy.ndarray):
                 self._data = self._storage.gpu_view
+            # must re-initialize compute domain view with new array
+            # this also can be removed when we merge GDP-3
+            self._compute_domain_view = BoundedArrayView(
+                self.data, self.dims, self.origin, self.extent
+            )
         return self._storage
 
     @property

--- a/tests/quantity/test_storage.py
+++ b/tests/quantity/test_storage.py
@@ -119,3 +119,15 @@ def test_modifying_storage_modifies_data_after_transpose(quantity):
     storage = quantity.storage
     quantity.data[:] = 5
     assert quantity.np.all(quantity.np.asarray(storage) == 5)
+
+@pytest.mark.parametrize("backend", ["numpy", "cupy"], indirect=True)
+def test_accessing_storage_does_not_break_view(
+    data, origin, extent, dims, units, backend
+):
+    if backend == "cupy":
+        backend = "gtcuda"
+    quantity = fv3gfs.util.Quantity(
+        data, origin=origin, extent=extent, dims=dims, units=units, gt4py_backend=backend
+    )
+    quantity.storage[origin] = -1.
+    assert quantity.data[origin] == quantity.view[tuple(0 for _ in origin)]

--- a/tests/quantity/test_storage.py
+++ b/tests/quantity/test_storage.py
@@ -120,6 +120,7 @@ def test_modifying_storage_modifies_data_after_transpose(quantity):
     quantity.data[:] = 5
     assert quantity.np.all(quantity.np.asarray(storage) == 5)
 
+
 @pytest.mark.parametrize("backend", ["numpy", "cupy"], indirect=True)
 def test_accessing_storage_does_not_break_view(
     data, origin, extent, dims, units, backend
@@ -127,7 +128,12 @@ def test_accessing_storage_does_not_break_view(
     if backend == "cupy":
         backend = "gtcuda"
     quantity = fv3gfs.util.Quantity(
-        data, origin=origin, extent=extent, dims=dims, units=units, gt4py_backend=backend
+        data,
+        origin=origin,
+        extent=extent,
+        dims=dims,
+        units=units,
+        gt4py_backend=backend,
     )
-    quantity.storage[origin] = -1.
+    quantity.storage[origin] = -1.0
     assert quantity.data[origin] == quantity.view[tuple(0 for _ in origin)]


### PR DESCRIPTION
Accessing `.storage` on a quantity which was initialized with a numpy or cupy array and a gt4py_backend value currently causes `view` to become out of sync with the underlying data of the quantity, since the data is re-allocated in creating the storage but the view is unchanged and retains a reference to the old data. This PR updates the routine which re-allocates the data to also update the view.

This is a work-around to deal with not being able to initialize gt4py storages from existing numpy or cupy arrays. We should be able to remove the work-around after GDP-3 (https://github.com/GridTools/gt4py/pull/28) is merged.