### PR TITLE
add tests and fixes for view bugs

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -21,6 +21,8 @@ in the `coupler_nml` namelist.
 
 Fixes:
 - Fixed a bug where quantity.storage and quantity.data could be out of sync if the quantity was initialized using data and a gt4py backend string
+- Default end value for corner views (e.g. quantity.view.southwest) is now correctly set to that corner
+- Default slice for corner views when not given at all as an index (e.g. when providing one index to a 2D view) now gives the same result as providing an empty slice (:)
 
 v0.5.1
 ------

--- a/fv3gfs/util/_boundary_utils.py
+++ b/fv3gfs/util/_boundary_utils.py
@@ -5,6 +5,11 @@ from ._exceptions import OutOfBoundsError
 
 
 def shift_boundary_slice_tuple(dims, origin, extent, boundary_type, slice_tuple):
+    """
+    Given the necessary information, shift a tuple of slices by the location
+    of the boundary, and set the default start and end indices for slices to that
+    boundary.
+    """
     slice_list = []
     for dim, entry, origin_1d, extent_1d in zip(dims, slice_tuple, origin, extent):
         slice_list.append(
@@ -22,18 +27,16 @@ def bound_default_slice(slice_in, start=None, stop=None):
 
 
 def _shift_boundary_slice(dim, origin, extent, boundary_type, slice_object):
-    """A special case of _get_boundary_slice where one edge must be an interior or
-    exterior halo point."""
     start_offset, stop_offset = _get_offset(boundary_type, dim, origin, extent)
     if isinstance(slice_object, slice):
         if slice_object.start is not None:
             start = slice_object.start + start_offset
         else:
-            start = slice_object.start
+            start = start_offset
         if slice_object.stop is not None:
             stop = slice_object.stop + stop_offset
         else:
-            stop = slice_object.stop
+            stop = stop_offset
         return bound_default_slice(
             slice(start, stop, slice_object.step), origin, origin + extent
         )

--- a/fv3gfs/util/quantity.py
+++ b/fv3gfs/util/quantity.py
@@ -77,11 +77,17 @@ class BoundaryArrayView:
         self._data[self._get_array_index(index)] = value
 
     def _get_array_index(self, index):
+        if isinstance(index, list):
+            index = tuple(index)
+        if not isinstance(index, tuple):
+            index = (index,)
         if len(index) > len(self._dims):
             raise IndexError(
                 f"{len(index)} is too many indices for a "
                 f"{len(self._dims)}-dimensional quantity"
             )
+        if len(index) < len(self._dims):
+            index = index + (slice(None, None),) * (len(self._dims) - len(index))
         return shift_boundary_slice_tuple(
             self._dims, self._origin, self._extent, self._boundary_type, index
         )

--- a/tests/quantity/test_boundary.py
+++ b/tests/quantity/test_boundary.py
@@ -171,7 +171,7 @@ def test_boundary_data_2_by_2_array_2_halo():
             3,
             fv3gfs.util.WEST,
             slice(None, None),
-            slice(1, 4),
+            slice(1, 1),
             id="none_is_changed",
         ),
         pytest.param(
@@ -180,7 +180,7 @@ def test_boundary_data_2_by_2_array_2_halo():
             3,
             fv3gfs.util.WEST,
             slice(None, None),
-            slice(1, 4),
+            slice(1, 1),
             id="perpendicular_none_is_changed",
         ),
         pytest.param(

--- a/tests/quantity/test_view.py
+++ b/tests/quantity/test_view.py
@@ -749,9 +749,34 @@ def test_many_slices_raises(quantity, view_name):
                 origin=(1, 1),
                 extent=(1, 1),
             ),
+            slice(None, None),
+            # need to make a non-empty array to get empty array
+            np.array([[1]])[0:0, 0:0],
+            id="3_by_3_default",
+        ),
+        pytest.param(
+            fv3gfs.util.Quantity(
+                np.array([[0, 1, 2], [3, 4, 5], [6, 7, 8]]),
+                dims=[fv3gfs.util.X_DIM, fv3gfs.util.Y_DIM],
+                units="m",
+                origin=(1, 1),
+                extent=(1, 1),
+            ),
             (-1, -1),
             0,
             id="3_by_3_corner",
+        ),
+        pytest.param(
+            fv3gfs.util.Quantity(
+                np.array([[0, 1, 2], [3, 4, 5], [6, 7, 8]]),
+                dims=[fv3gfs.util.X_DIM, fv3gfs.util.Y_DIM],
+                units="m",
+                origin=(1, 1),
+                extent=(1, 1),
+            ),
+            (slice(-1, None), slice(-1, None)),
+            np.array([[0]]),
+            id="3_by_3_corner_as_slice_with_default_end",
         ),
         pytest.param(
             fv3gfs.util.Quantity(
@@ -811,11 +836,12 @@ def test_southwest(quantity, view_slice, reference):
         origin=quantity.origin[::-1],
         extent=quantity.extent[::-1],
     )
-    transposed_result = transposed_quantity.view.southwest[view_slice[::-1]]
-    if isinstance(reference, quantity.np.ndarray):
-        quantity.np.testing.assert_array_equal(transposed_result, reference.T)
-    else:
-        quantity.np.testing.assert_array_equal(transposed_result, reference)
+    if isinstance(view_slice, tuple):  # skip for empty slice case
+        transposed_result = transposed_quantity.view.southwest[view_slice[::-1]]
+        if isinstance(reference, quantity.np.ndarray):
+            quantity.np.testing.assert_array_equal(transposed_result, reference.T)
+        else:
+            quantity.np.testing.assert_array_equal(transposed_result, reference)
 
 
 @pytest.mark.parametrize(
@@ -1177,6 +1203,26 @@ def test_northeast(quantity, view_slice, reference):
             np.array([[2, 3], [7, 8], [12, 13]]),
             id="5_by_5_larger_slice",
         ),
+        pytest.param(
+            fv3gfs.util.Quantity(
+                np.array(
+                    [
+                        [0, 1, 2, 3, 4],
+                        [5, 6, 7, 8, 9],
+                        [10, 11, 12, 13, 14],
+                        [15, 16, 17, 18, 19],
+                        [20, 21, 22, 23, 24],
+                    ]
+                ),
+                dims=[fv3gfs.util.X_DIM, fv3gfs.util.Y_DIM],
+                units="m",
+                origin=(1, 1),
+                extent=(3, 3),
+            ),
+            (0,),
+            np.array([6, 7, 8]),
+            id="5_by_5_one_index",
+        ),
     ],
 )
 def test_interior(quantity, view_slice, reference):
@@ -1191,8 +1237,9 @@ def test_interior(quantity, view_slice, reference):
         origin=quantity.origin[::-1],
         extent=quantity.extent[::-1],
     )
-    transposed_result = transposed_quantity.view.interior[view_slice[::-1]]
-    if isinstance(reference, quantity.np.ndarray):
-        quantity.np.testing.assert_array_equal(transposed_result, reference.T)
-    else:
-        quantity.np.testing.assert_array_equal(transposed_result, reference)
+    if len(view_slice) == len(quantity.dims):  # skip if not
+        transposed_result = transposed_quantity.view.interior[view_slice[::-1]]
+        if isinstance(reference, quantity.np.ndarray):
+            quantity.np.testing.assert_array_equal(transposed_result, reference.T)
+        else:
+            quantity.np.testing.assert_array_equal(transposed_result, reference)


### PR DESCRIPTION
Closing this PR for now and considering updating the documentation/workshop material to reflect the current behavior, which may actually be more useful. Leaving the original PR below in case it is restored.

-----

Fixed two bugs in the way corner views perform index offsetting:
- Default end value for corner views (e.g. quantity.view.southwest) is now correctly set to that corner
- Default slice for corner views when not given at all as an index (e.g. when providing one index to a 2D view) now gives the same result as providing an empty slice (:)

This was not caught earlier because existing code which uses the corner views passes all start and end indices explicitly. As context for reviewers, having the default end value be the same as the default start value is necessary for things like having the southwest corner of a 2D array be accessible by quantity.view.southwest[-2:, -2:] and its interior corner be quantity.view.southwest[:2, :2]. The default slice for these corners is empty, but that is because there is no use case for a default corner slice (one would be using quantity.view.interior or quantity.view in that case).

This will likely require as a follow-on adding back the edge views which are currently in the code but commented (e.g. quantity.view.west) which would default to the compute range for one of the axes, e.g. so quantity.view.west[-1:, :] gives you the entire west edge instead of quantity.view.southwest[-1:, :] which would give an empty array because the second axis defaults to 0:0.

The design itself of how these edges behave is subject to change as we use it for more use cases, but for now this simply fixes the code to follow the intended behavior as in the documentation, for the upcoming workshop.