### PR TITLE
Fix error when passing fewer indices to view than there are dims

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -21,6 +21,7 @@ in the `coupler_nml` namelist.
 
 Fixes:
 - Fixed a bug where quantity.storage and quantity.data could be out of sync if the quantity was initialized using data and a gt4py backend string
+- Default slice for corner views when not given at all as an index (e.g. when providing one index to a 2D view) now gives the same result as providing an empty slice (:)
 - Fixed a bug where quantity.view could refer to a different array than quantity.data if the quantity was initialized using data and a gt4py backend string, and then quantity.storage was accessed
 
 v0.5.1

--- a/fv3gfs/util/_boundary_utils.py
+++ b/fv3gfs/util/_boundary_utils.py
@@ -22,8 +22,7 @@ def bound_default_slice(slice_in, start=None, stop=None):
 
 
 def _shift_boundary_slice(dim, origin, extent, boundary_type, slice_object):
-    """A special case of _get_boundary_slice where one edge must be an interior or
-    exterior halo point."""
+    """_get_boundary_slice for corner views"""
     start_offset, stop_offset = _get_offset(boundary_type, dim, origin, extent)
     if isinstance(slice_object, slice):
         if slice_object.start is not None:

--- a/fv3gfs/util/quantity.py
+++ b/fv3gfs/util/quantity.py
@@ -77,11 +77,17 @@ class BoundaryArrayView:
         self._data[self._get_array_index(index)] = value
 
     def _get_array_index(self, index):
+        if isinstance(index, list):
+            index = tuple(index)
+        if not isinstance(index, tuple):
+            index = (index,)
         if len(index) > len(self._dims):
             raise IndexError(
                 f"{len(index)} is too many indices for a "
                 f"{len(self._dims)}-dimensional quantity"
             )
+        if len(index) < len(self._dims):
+            index = index + (slice(None, None),) * (len(self._dims) - len(index))
         return shift_boundary_slice_tuple(
             self._dims, self._origin, self._extent, self._boundary_type, index
         )

--- a/tests/quantity/test_view.py
+++ b/tests/quantity/test_view.py
@@ -1097,6 +1097,26 @@ def test_northwest(quantity, view_slice, reference):
             np.array([[7, 8, 9], [12, 13, 14]]),
             id="5_by_5_larger_slice",
         ),
+        pytest.param(
+            fv3gfs.util.Quantity(
+                np.array(
+                    [
+                        [0, 1, 2, 3, 4],
+                        [5, 6, 7, 8, 9],
+                        [10, 11, 12, 13, 14],
+                        [15, 16, 17, 18, 19],
+                        [20, 21, 22, 23, 24],
+                    ]
+                ),
+                dims=[fv3gfs.util.X_DIM, fv3gfs.util.Y_DIM],
+                units="m",
+                origin=(1, 1),
+                extent=(3, 3),
+            ),
+            (0,),
+            np.array([6, 7, 8]),
+            id="5_by_5_one_index",
+        ),
     ],
 )
 def test_northeast(quantity, view_slice, reference):
@@ -1111,11 +1131,12 @@ def test_northeast(quantity, view_slice, reference):
         origin=quantity.origin[::-1],
         extent=quantity.extent[::-1],
     )
-    transposed_result = transposed_quantity.view.northeast[view_slice[::-1]]
-    if isinstance(reference, quantity.np.ndarray):
-        quantity.np.testing.assert_array_equal(transposed_result, reference.T)
-    else:
-        quantity.np.testing.assert_array_equal(transposed_result, reference)
+    if len(view_slice) == len(quantity.dims):  # skip if not
+        transposed_result = transposed_quantity.view.interior[view_slice[::-1]]
+        if isinstance(reference, quantity.np.ndarray):
+            quantity.np.testing.assert_array_equal(transposed_result, reference.T)
+        else:
+            quantity.np.testing.assert_array_equal(transposed_result, reference)
 
 
 @pytest.mark.parametrize(

--- a/tests/quantity/test_view.py
+++ b/tests/quantity/test_view.py
@@ -1097,26 +1097,6 @@ def test_northwest(quantity, view_slice, reference):
             np.array([[7, 8, 9], [12, 13, 14]]),
             id="5_by_5_larger_slice",
         ),
-        pytest.param(
-            fv3gfs.util.Quantity(
-                np.array(
-                    [
-                        [0, 1, 2, 3, 4],
-                        [5, 6, 7, 8, 9],
-                        [10, 11, 12, 13, 14],
-                        [15, 16, 17, 18, 19],
-                        [20, 21, 22, 23, 24],
-                    ]
-                ),
-                dims=[fv3gfs.util.X_DIM, fv3gfs.util.Y_DIM],
-                units="m",
-                origin=(1, 1),
-                extent=(3, 3),
-            ),
-            (0,),
-            np.array([6, 7, 8]),
-            id="5_by_5_one_index",
-        ),
     ],
 )
 def test_northeast(quantity, view_slice, reference):
@@ -1131,12 +1111,11 @@ def test_northeast(quantity, view_slice, reference):
         origin=quantity.origin[::-1],
         extent=quantity.extent[::-1],
     )
-    if len(view_slice) == len(quantity.dims):  # skip if not
-        transposed_result = transposed_quantity.view.interior[view_slice[::-1]]
-        if isinstance(reference, quantity.np.ndarray):
-            quantity.np.testing.assert_array_equal(transposed_result, reference.T)
-        else:
-            quantity.np.testing.assert_array_equal(transposed_result, reference)
+    transposed_result = transposed_quantity.view.northeast[view_slice[::-1]]
+    if isinstance(reference, quantity.np.ndarray):
+        quantity.np.testing.assert_array_equal(transposed_result, reference.T)
+    else:
+        quantity.np.testing.assert_array_equal(transposed_result, reference)
 
 
 @pytest.mark.parametrize(
@@ -1198,6 +1177,26 @@ def test_northeast(quantity, view_slice, reference):
             np.array([[2, 3], [7, 8], [12, 13]]),
             id="5_by_5_larger_slice",
         ),
+        pytest.param(
+            fv3gfs.util.Quantity(
+                np.array(
+                    [
+                        [0, 1, 2, 3, 4],
+                        [5, 6, 7, 8, 9],
+                        [10, 11, 12, 13, 14],
+                        [15, 16, 17, 18, 19],
+                        [20, 21, 22, 23, 24],
+                    ]
+                ),
+                dims=[fv3gfs.util.X_DIM, fv3gfs.util.Y_DIM],
+                units="m",
+                origin=(1, 1),
+                extent=(3, 3),
+            ),
+            (0,),
+            np.array([6, 7, 8]),
+            id="5_by_5_one_index",
+        ),
     ],
 )
 def test_interior(quantity, view_slice, reference):
@@ -1212,8 +1211,9 @@ def test_interior(quantity, view_slice, reference):
         origin=quantity.origin[::-1],
         extent=quantity.extent[::-1],
     )
-    transposed_result = transposed_quantity.view.interior[view_slice[::-1]]
-    if isinstance(reference, quantity.np.ndarray):
-        quantity.np.testing.assert_array_equal(transposed_result, reference.T)
-    else:
-        quantity.np.testing.assert_array_equal(transposed_result, reference)
+    if len(view_slice) == len(quantity.dims):  # skip if not
+        transposed_result = transposed_quantity.view.interior[view_slice[::-1]]
+        if isinstance(reference, quantity.np.ndarray):
+            quantity.np.testing.assert_array_equal(transposed_result, reference.T)
+        else:
+            quantity.np.testing.assert_array_equal(transposed_result, reference)


### PR DESCRIPTION
Numpy arrays allow indexing on only the first dimensions, and fill in empty slices for later dimensions. This PR updates the behavior of `Quantity.view` to reflect this. Without it, `quantity.view.southwest[:]` raises `TypeError: object of type 'slice' has no len()`, and this does not match the behavior of `quantity.view[:]` which returns a numpy array.