### PR TITLE
Init Quantity with numpy array and gpu backend should create gpu storage/array

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -17,7 +17,10 @@ in the `coupler_nml` namelist.
 - Halo updates now use tagged send/recv operations, which prevents deadlocks in certain situations
 - Quantity.data is now guaranteed to be a numpy or cupy array matching its `.np` module, and will no longer be a gt4py Storage
 - Quantity accepts a `gt4py_backend` on initialize which is used to create its `.storage` if one was not used on initialize
-- parent MPI rank now referred to as "root" rank in variable names and documentation
+- parent MPI rank now referred to as "root" rank in variable names and documentation- Fixed a bug where initializing a Quantity with a numpy array and a gpu backend would give CPUStorage
+- raise TypeError if initializing a quantity with both a storage and a gt4py_backend argument
+- eagerly create storage object when initializing Quantity
+- make data type of quantity and storage reflect the gt4py_backend chosen, instead of being determined based on the data type being numpy/cupy
 
 Fixes:
 - Fixed a bug where quantity.storage and quantity.data could be out of sync if the quantity was initialized using data and a gt4py backend string

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -17,7 +17,8 @@ in the `coupler_nml` namelist.
 - Halo updates now use tagged send/recv operations, which prevents deadlocks in certain situations
 - Quantity.data is now guaranteed to be a numpy or cupy array matching its `.np` module, and will no longer be a gt4py Storage
 - Quantity accepts a `gt4py_backend` on initialize which is used to create its `.storage` if one was not used on initialize
-- parent MPI rank now referred to as "root" rank in variable names and documentation- Fixed a bug where initializing a Quantity with a numpy array and a gpu backend would give CPUStorage
+- parent MPI rank now referred to as "root" rank in variable names and documentation
+- Fixed a bug where initializing a Quantity with a numpy array and a gpu backend would give CPUStorage
 - raise TypeError if initializing a quantity with both a storage and a gt4py_backend argument
 - eagerly create storage object when initializing Quantity
 - make data type of quantity and storage reflect the gt4py_backend chosen, instead of being determined based on the data type being numpy/cupy

--- a/fv3gfs/util/_legacy_restart.py
+++ b/fv3gfs/util/_legacy_restart.py
@@ -139,7 +139,7 @@ def prepend_label(filename, label=None):
 def load_partial_state_from_restart_file(
     file, restart_properties: RestartProperties, only_names=None
 ):
-    ds = xr.open_dataset(file).isel(Time=0).drop("Time")
+    ds = xr.open_dataset(file).isel(Time=0).drop_vars("Time")
     state = map_keys(ds.data_vars, _get_restart_standard_names(restart_properties))
     state = _apply_restart_metadata(state, restart_properties)
     if only_names is None:

--- a/fv3gfs/util/quantity.py
+++ b/fv3gfs/util/quantity.py
@@ -276,12 +276,12 @@ class Quantity:
             origin = (0,) * len(dims)  # default origin at origin of array
         else:
             origin = tuple(origin)
-        
+
         if extent is None:
             extent = tuple(length - start for length, start in zip(data.shape, origin))
         else:
             extent = tuple(extent)
-        
+
         if isinstance(data, (int, float, list)):
             data = np.asarray(data)
         elif gt4py is not None and isinstance(data, gt4py.storage.storage.Storage):
@@ -304,8 +304,8 @@ class Quantity:
                     f"got {type(data)}"
                 )
         elif gt4py_backend is not None:
-            self._storage, self._data = (
-                self._initialize_storage(data, origin, gt4py_backend)
+            self._storage, self._data = self._initialize_storage(
+                data, origin, gt4py_backend
             )
         else:
             self._data = data
@@ -389,7 +389,7 @@ class Quantity:
                 "gt4py backend was not specified when initializing this object"
             )
         return self._storage
-    
+
     def _initialize_storage(self, data, origin, gt4py_backend: str):
         print(origin)
         storage = gt4py.storage.storage.empty(

--- a/fv3gfs/util/quantity.py
+++ b/fv3gfs/util/quantity.py
@@ -269,7 +269,7 @@ class Quantity:
             extent: number of points along each axis within the computational domain
             gt4py_backend: backend to use for gt4py storages, if not given this will
                 be derived from a Storage if given as the data argument, otherwise the
-                storage attribute is disabled and will raise an exception. will raise
+                storage attribute is disabled and will raise an exception. Will raise
                 a TypeError if this is given with a gt4py storage type as data
         """
         if origin is None:
@@ -391,7 +391,6 @@ class Quantity:
         return self._storage
 
     def _initialize_storage(self, data, origin, gt4py_backend: str):
-        print(origin)
         storage = gt4py.storage.storage.empty(
             gt4py_backend,
             default_origin=origin,

--- a/fv3gfs/util/quantity.py
+++ b/fv3gfs/util/quantity.py
@@ -269,12 +269,29 @@ class Quantity:
             extent: number of points along each axis within the computational domain
             gt4py_backend: backend to use for gt4py storages, if not given this will
                 be derived from a Storage if given as the data argument, otherwise the
-                storage attribute is disabled and will raise an exception
+                storage attribute is disabled and will raise an exception. will raise
+                a TypeError if this is given with a gt4py storage type as data
         """
+        if origin is None:
+            origin = (0,) * len(dims)  # default origin at origin of array
+        else:
+            origin = tuple(origin)
+        
+        if extent is None:
+            extent = tuple(length - start for length, start in zip(data.shape, origin))
+        else:
+            extent = tuple(extent)
+        
         if isinstance(data, (int, float, list)):
             data = np.asarray(data)
         elif gt4py is not None and isinstance(data, gt4py.storage.storage.Storage):
-            gt4py_backend = data.backend
+            if gt4py_backend is not None:
+                raise TypeError(
+                    "cannot select gt4py backend with keyword argument "
+                    "when providing storage as data"
+                )
+            else:
+                gt4py_backend = data.backend
             if isinstance(data, gt4py.storage.storage.GPUStorage):
                 self._storage = data
                 self._data = data.gpu_view
@@ -286,18 +303,14 @@ class Quantity:
                     "only storages supported are CPUStorage and GPUStorage, "
                     f"got {type(data)}"
                 )
+        elif gt4py_backend is not None:
+            self._storage, self._data = (
+                self._initialize_storage(data, origin, gt4py_backend)
+            )
         else:
-            self._storage = None
             self._data = data
+            self._storage = None
 
-        if origin is None:
-            origin = (0,) * len(dims)  # default origin at origin of array
-        else:
-            origin = tuple(origin)
-        if extent is None:
-            extent = tuple(length - start for length, start in zip(data.shape, origin))
-        else:
-            extent = tuple(extent)
         _validate_quantity_property_lengths(data.shape, dims, origin, extent)
         self._metadata = QuantityMetadata(
             origin=ensure_int_tuple(origin, "origin"),
@@ -371,40 +384,36 @@ class Quantity:
         this object, either by providing a Storage for data or explicitly specifying
         a backend.
         """
-        if gt4py is None:
-            raise ImportError("gt4py is not installed")
-        elif self._storage is None and self.gt4py_backend is None:
+        if self._storage is None:
             raise TypeError(
-                "Quantity was initialized with a non-storage type and "
-                "no gt4py backend was given"
-            )
-        elif self._storage is None:
-            if isinstance(self._data, np.ndarray):
-                storage_type = gt4py.storage.storage.CPUStorage
-            elif isinstance(self._data, cupy.ndarray):
-                storage_type = gt4py.storage.storage.GPUStorage
-            self._storage = storage_type(
-                shape=self._data.shape,
-                dtype=self._data.dtype,
-                backend=self.gt4py_backend,
-                default_origin=self.origin,
-                mask=None,
-            )
-            self._storage[...] = self._data
-            # storage must initialize new memory. when GDP-3 is merged, we can instead
-            # initialize storage from self._data
-            # when GDP-3 is merged, we can instead use the data in self._data to
-            # initialize the storage, instead of making a copy.
-            if isinstance(self._data, np.ndarray):
-                self._data = self.np.asarray(self._storage.data)
-            elif isinstance(self._data, cupy.ndarray):
-                self._data = self._storage.gpu_view
-            # must re-initialize compute domain view with new array
-            # this also can be removed when we merge GDP-3
-            self._compute_domain_view = BoundedArrayView(
-                self.data, self.dims, self.origin, self.extent
+                "gt4py backend was not specified when initializing this object"
             )
         return self._storage
+    
+    def _initialize_storage(self, data, origin, gt4py_backend: str):
+        print(origin)
+        storage = gt4py.storage.storage.empty(
+            gt4py_backend,
+            default_origin=origin,
+            shape=data.shape,
+            dtype=data.dtype,
+            managed_memory=True,  # required to get GPUStorage with only gpu data copy
+        )
+        storage[...] = data
+        # storage must initialize new memory. when GDP-3 is merged, we can instead
+        # initialize storage from self._data
+        # when GDP-3 is merged, we can instead use the data in self._data to
+        # initialize the storage, instead of making a copy.
+        if isinstance(storage, gt4py.storage.storage.CPUStorage):
+            data = np.asarray(storage.data)
+        elif isinstance(storage, gt4py.storage.storage.GPUStorage):
+            data = storage.gpu_view
+        else:
+            raise NotImplementedError(
+                f"received unexpected storage type {type(storage)} "
+                f"for gt4py_backend {gt4py_backend}, did gt4py get updated?"
+            )
+        return storage, data
 
     @property
     def metadata(self) -> QuantityMetadata:

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,3 +31,4 @@ toolz==0.10.0
 scipy==1.3.1
 git+https://github.com/GridTools/gt4py.git@db40777788863bfe87b9674b118e8bd5b8db0440#egg=gt4py
 cftime==1.2.1
+typing_extensions

--- a/tests/quantity/test_storage.py
+++ b/tests/quantity/test_storage.py
@@ -154,3 +154,33 @@ def test_numpy_data_becomes_cupy_with_gpu_backend(
     )
     assert isinstance(quantity.data, cupy.ndarray)
     assert isinstance(quantity.storage, gt4py.storage.storage.GPUStorage)
+
+@pytest.mark.parametrize("backend", ["gt4py_numpy"], indirect=True)
+def test_cannot_use_cpu_storage_with_gpu_backend(
+    data, origin, extent, dims, units, backend
+):
+    assert isinstance(data, gt4py.storage.storage.CPUStorage)
+    with pytest.raises(TypeError):
+        fv3gfs.util.Quantity(
+            data,
+            origin=origin,
+            extent=extent,
+            dims=dims,
+            units=units,
+            gt4py_backend="gtcuda",
+        )
+
+@pytest.mark.parametrize("backend", ["gt4py_cupy"], indirect=True)
+def test_cannot_use_gpu_storage_with_cpu_backend(
+    data, origin, extent, dims, units, backend
+):
+    assert isinstance(data, gt4py.storage.storage.GPUStorage)
+    with pytest.raises(TypeError):
+        fv3gfs.util.Quantity(
+            data,
+            origin=origin,
+            extent=extent,
+            dims=dims,
+            units=units,
+            gt4py_backend="numpy",
+        )

--- a/tests/quantity/test_storage.py
+++ b/tests/quantity/test_storage.py
@@ -138,6 +138,7 @@ def test_accessing_storage_does_not_break_view(
     quantity.storage[origin] = -1.0
     assert quantity.data[origin] == quantity.view[tuple(0 for _ in origin)]
 
+
 # run using cupy backend even though unused, to mark this as a "gpu" test
 @pytest.mark.parametrize("backend", ["cupy"], indirect=True)
 def test_numpy_data_becomes_cupy_with_gpu_backend(
@@ -155,6 +156,7 @@ def test_numpy_data_becomes_cupy_with_gpu_backend(
     assert isinstance(quantity.data, cupy.ndarray)
     assert isinstance(quantity.storage, gt4py.storage.storage.GPUStorage)
 
+
 @pytest.mark.parametrize("backend", ["gt4py_numpy"], indirect=True)
 def test_cannot_use_cpu_storage_with_gpu_backend(
     data, origin, extent, dims, units, backend
@@ -169,6 +171,7 @@ def test_cannot_use_cpu_storage_with_gpu_backend(
             units=units,
             gt4py_backend="gtcuda",
         )
+
 
 @pytest.mark.parametrize("backend", ["gt4py_cupy"], indirect=True)
 def test_cannot_use_gpu_storage_with_cpu_backend(

--- a/tests/quantity/test_storage.py
+++ b/tests/quantity/test_storage.py
@@ -137,3 +137,20 @@ def test_accessing_storage_does_not_break_view(
     )
     quantity.storage[origin] = -1.0
     assert quantity.data[origin] == quantity.view[tuple(0 for _ in origin)]
+
+# run using cupy backend even though unused, to mark this as a "gpu" test
+@pytest.mark.parametrize("backend", ["cupy"], indirect=True)
+def test_numpy_data_becomes_cupy_with_gpu_backend(
+    data, origin, extent, dims, units, backend
+):
+    cpu_data = np.zeros(data.shape)
+    quantity = fv3gfs.util.Quantity(
+        cpu_data,
+        origin=origin,
+        extent=extent,
+        dims=dims,
+        units=units,
+        gt4py_backend="gtcuda",
+    )
+    assert isinstance(quantity.data, cupy.ndarray)
+    assert isinstance(quantity.storage, gt4py.storage.storage.GPUStorage)


### PR DESCRIPTION
Main changes:
- Fixed a bug where initializing a Quantity with a numpy array and a gpu backend would give CPUStorage
- raise TypeError if initializing a quantity with both a storage and a gt4py_backend argument
- eagerly create storage object when initializing Quantity
- make data type of quantity and storage reflect the gt4py_backend chosen, instead of being determined based on the data type being numpy/cupy

Other small fixes:
- use xarray's drop_vars instead of deprecated `drop` routine in `open_restart`
- add typing_extensions to requirements, was left out when added as import in previous PR