### PR TITLE
Fix bug for calculation of mean in global_timings.py

### DIFF
--- a/examples/mpi/global_timings.py
+++ b/examples/mpi/global_timings.py
@@ -18,7 +18,7 @@ def print_global_timings(times, comm, root=0):
         for label, op in [("min", MPI.MIN), ("max", MPI.MAX), ("mean", MPI.SUM)]:
             comm.Reduce(np.array(value), recvbuf, op=op)
             if is_root:
-                if op == "mean":
+                if label == "mean":
                     recvbuf /= comm.Get_size()
                 print(f"    {label}: {recvbuf}")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ fsspec==0.8.0
 kubernetes==10.0.1
 black==19.10b0
 xarray==0.15.1
-numpy==1.16.4
+numpy==1.16.5
 numcodecs==0.7.2
 zarr==2.3.2
 h5py==2.10.0


### PR DESCRIPTION
Currently the reported mean value is too large by a factor of # of ranks.