### PR TITLE
Don't include "time" in state returned from open_restart if it is not provided in only_names

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,6 +5,7 @@ latest
 ------
 
 Major changes:
+- If `only_names` is provided to `open_restart`, it will return those fields and nothing more.  Previously it would include `"time"` in the returned state even if it was not requested.
 - Use `cftime.datetime` objects to represent datetimes instead
 of `datetime.datetime` objects.  This results in times stored in a format compatible with
 the fortran model, and accurate internal representation of times with the calendar specified

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,7 +5,6 @@ latest
 ------
 
 Major changes:
-- If `only_names` is provided to `open_restart`, it will return those fields and nothing more.  Previously it would include `"time"` in the returned state even if it was not requested.
 - Use `cftime.datetime` objects to represent datetimes instead
 of `datetime.datetime` objects.  This results in times stored in a format compatible with
 the fortran model, and accurate internal representation of times with the calendar specified
@@ -30,6 +29,7 @@ in the `coupler_nml` namelist.
 - make data type of quantity and storage reflect the gt4py_backend chosen, instead of being determined based on the data type being numpy/cupy
 
 Fixes:
+- If `only_names` is provided to `open_restart`, it will return those fields and nothing more.  Previously it would include `"time"` in the returned state even if it was not requested.
 - Fixed a bug where quantity.storage and quantity.data could be out of sync if the quantity was initialized using data and a gt4py backend string
 - Default slice for corner views when not given at all as an index (e.g. when providing one index to a 2D view) now gives the same result as providing an empty slice (:)
 - Fixed a bug where quantity.view could refer to a different array than quantity.data if the quantity was initialized using data and a gt4py backend string, and then quantity.storage was accessed

--- a/fv3gfs/util/_legacy_restart.py
+++ b/fv3gfs/util/_legacy_restart.py
@@ -53,8 +53,9 @@ def open_restart(
             )
         coupler_res_filename = get_coupler_res_filename(dirname, label)
         if filesystem.is_file(coupler_res_filename):
-            with filesystem.open(coupler_res_filename, "r") as f:
-                state["time"] = io.get_current_date_from_coupler_res(f)
+            if only_names is None or "time" in only_names:
+                with filesystem.open(coupler_res_filename, "r") as f:
+                    state["time"] = io.get_current_date_from_coupler_res(f)
     if to_state is None:
         state = communicator.tile.scatter_state(state)
     else:


### PR DESCRIPTION
Fixes #38

Now if a user specifies a non-None `only_names`, only fields included in `only_names` are in the returned state (`"time"` no longer is always returned).