### PR TITLE
Fix gpu halo update on cpu

### DIFF
--- a/fv3gfs/util/buffer.py
+++ b/fv3gfs/util/buffer.py
@@ -2,6 +2,7 @@ from typing import Callable, Iterable, Optional, Dict, Tuple
 from ._timing import Timer, NullTimer
 from numpy import ndarray
 import contextlib
+
 try:
     import cupy as cp
 except ModuleNotFoundError:

--- a/fv3gfs/util/buffer.py
+++ b/fv3gfs/util/buffer.py
@@ -1,5 +1,6 @@
 from typing import Callable, Iterable, Optional, Dict, Tuple
 from ._timing import Timer, NullTimer
+from cupy import asarray
 from numpy import ndarray
 import contextlib
 from .utils import is_c_contiguous
@@ -91,4 +92,4 @@ def recv_buffer(allocator: Callable, array: ndarray, timer: Optional[Timer] = No
             timer.stop("unpack")
             yield recvbuf
             with timer.clock("unpack"):
-                array[:] = recvbuf
+                array[:] = asarray(recvbuf)

--- a/fv3gfs/util/buffer.py
+++ b/fv3gfs/util/buffer.py
@@ -101,5 +101,7 @@ def recv_buffer(allocator: Callable, array: ndarray, timer: Optional[Timer] = No
                 # errors on the cupy arrays from gt4py storages.
                 # This should be fixed in a later version of gt4py
                 array[:] = (
-                    cp.asarray(recvbuf) if isinstance(array, cp.ndarray) else recvbuf
+                    cp.asarray(recvbuf)
+                    if cp and isinstance(array, cp.ndarray)
+                    else recvbuf
                 )

--- a/fv3gfs/util/buffer.py
+++ b/fv3gfs/util/buffer.py
@@ -1,8 +1,8 @@
 from typing import Callable, Iterable, Optional, Dict, Tuple
 from ._timing import Timer, NullTimer
-from cupy import asarray
 from numpy import ndarray
 import contextlib
+import cupy as cp
 from .utils import is_c_contiguous
 from .types import Allocator
 
@@ -92,4 +92,4 @@ def recv_buffer(allocator: Callable, array: ndarray, timer: Optional[Timer] = No
             timer.stop("unpack")
             yield recvbuf
             with timer.clock("unpack"):
-                array[:] = asarray(recvbuf)
+                array[:] = cp.asarray(recvbuf) if isinstance(array, cp.ndarray) else recvbuf

--- a/fv3gfs/util/communicator.py
+++ b/fv3gfs/util/communicator.py
@@ -199,10 +199,7 @@ class Communicator:
                 result = recv_quantity
         else:
             self._Gather(
-                send_quantity.np,
-                send_quantity.view[:],
-                None,
-                root=constants.ROOT_RANK,
+                send_quantity.np, send_quantity.view[:], None, root=constants.ROOT_RANK,
             )
             result = None
         return result
@@ -449,10 +446,7 @@ class CubedSphereCommunicator(Communicator):
         )
 
     def vector_halo_update(
-        self,
-        x_quantity: Quantity,
-        y_quantity: Quantity,
-        n_points: int,
+        self, x_quantity: Quantity, y_quantity: Quantity, n_points: int,
     ):
         """Perform a halo update of a horizontal vector quantity.
 
@@ -518,10 +512,7 @@ class CubedSphereCommunicator(Communicator):
         req.wait()
 
     def start_vector_halo_update(
-        self,
-        x_quantity: Quantity,
-        y_quantity: Quantity,
-        n_points: int,
+        self, x_quantity: Quantity, y_quantity: Quantity, n_points: int,
     ) -> HaloUpdateRequest:
         """Start an asynchronous halo update of a horizontal vector quantity.
 
@@ -652,6 +643,7 @@ class CubedSphereCommunicator(Communicator):
             array = np.ascontiguousarray(
                 numpy.asnumpy(in_array) if hasattr(numpy, "asnumpy") else in_array
             )
+
         with self.timer.clock("Isend"):
             return self.comm.Isend(array, **kwargs)
 
@@ -676,10 +668,7 @@ class CubedSphereCommunicator(Communicator):
         return FunctionRequest(recv)
 
     def finish_vector_halo_update(
-        self,
-        x_quantity: Quantity,
-        y_quantity: Quantity,
-        n_points: int,
+        self, x_quantity: Quantity, y_quantity: Quantity, n_points: int,
     ):
         """Deprecated, do not use."""
         raise NotImplementedError(

--- a/fv3gfs/util/communicator.py
+++ b/fv3gfs/util/communicator.py
@@ -8,6 +8,7 @@ from .buffer import array_buffer, send_buffer, recv_buffer
 from ._timing import Timer
 import numpy as np
 import logging
+# import sys
 
 __all__ = [
     "TileCommunicator",
@@ -640,8 +641,9 @@ class CubedSphereCommunicator(Communicator):
         # don't want to use a buffer here, because we leave this scope and can't close
         # the context manager. might figure out a way to do it later
         with self.timer.clock("pack"):
-            array = np.ascontiguousarray(in_array)
+            array = np.ascontiguousarray(numpy.asnumpy(in_array))
         with self.timer.clock("Isend"):
+            # sys.stderr.write(f"_Isend({self.rank}): type(array)={type(array)}, array.shape={array.shape}\n")
             return self.comm.Isend(array, **kwargs)
 
     def _Send(self, numpy, in_array, **kwargs):
@@ -660,6 +662,7 @@ class CubedSphereCommunicator(Communicator):
         def recv():
             with recv_buffer(np.empty, out_array, timer=self.timer) as recvbuf:
                 with self.timer.clock("Recv"):
+                    # sys.stderr.write(f"_Irecv({self.rank}): type(recvbuf)={type(recvbuf)}, recvbuf.shape={recvbuf.shape}\n")
                     self.comm.Recv(recvbuf, **kwargs)
 
         return FunctionRequest(recv)

--- a/fv3gfs/util/communicator.py
+++ b/fv3gfs/util/communicator.py
@@ -8,7 +8,6 @@ from .buffer import array_buffer, send_buffer, recv_buffer
 from ._timing import Timer
 import numpy as np
 import logging
-# import sys
 
 __all__ = [
     "TileCommunicator",
@@ -643,7 +642,6 @@ class CubedSphereCommunicator(Communicator):
         with self.timer.clock("pack"):
             array = np.ascontiguousarray(numpy.asnumpy(in_array))
         with self.timer.clock("Isend"):
-            # sys.stderr.write(f"_Isend({self.rank}): type(array)={type(array)}, array.shape={array.shape}\n")
             return self.comm.Isend(array, **kwargs)
 
     def _Send(self, numpy, in_array, **kwargs):
@@ -662,7 +660,6 @@ class CubedSphereCommunicator(Communicator):
         def recv():
             with recv_buffer(np.empty, out_array, timer=self.timer) as recvbuf:
                 with self.timer.clock("Recv"):
-                    # sys.stderr.write(f"_Irecv({self.rank}): type(recvbuf)={type(recvbuf)}, recvbuf.shape={recvbuf.shape}\n")
                     self.comm.Recv(recvbuf, **kwargs)
 
         return FunctionRequest(recv)

--- a/fv3gfs/util/communicator.py
+++ b/fv3gfs/util/communicator.py
@@ -85,7 +85,7 @@ class Communicator:
     ) -> Quantity:
         """Transfer subtile regions of a full-tile quantity
         from the tile root rank to all subtiles.
-        
+
         Args:
             send_quantity: quantity to send, only required/used on the tile root rank
             recv_quantity: if provided, assign received data into this Quantity.
@@ -160,7 +160,7 @@ class Communicator:
     ) -> Optional[Quantity]:
         """Transfer subtile regions of a full-tile quantity
         from each rank to the tile root rank.
-        
+
         Args:
             send_quantity: quantity to send
             recv_quantity: if provided, assign received data into this Quantity (only
@@ -199,7 +199,10 @@ class Communicator:
                 result = recv_quantity
         else:
             self._Gather(
-                send_quantity.np, send_quantity.view[:], None, root=constants.ROOT_RANK,
+                send_quantity.np,
+                send_quantity.view[:],
+                None,
+                root=constants.ROOT_RANK,
             )
             result = None
         return result
@@ -236,7 +239,7 @@ class Communicator:
 
     def scatter_state(self, send_state=None, recv_state=None):
         """Transfer a state dictionary from the tile root rank to all subtiles.
-        
+
         Args:
             send_state: the model state to be sent containing the entire tile,
                 required only from the root rank
@@ -290,7 +293,7 @@ class TileCommunicator(Communicator):
 
     def __init__(self, comm, partitioner: TilePartitioner):
         """Initialize a TileCommunicator.
-        
+
         Args:
             comm: mpi4py.Comm object
             partitioner: tile partitioner
@@ -307,7 +310,7 @@ class CubedSphereCommunicator(Communicator):
 
     def __init__(self, comm, partitioner: CubedSpherePartitioner):
         """Initialize a CubedSphereCommunicator.
-        
+
         Args:
             comm: mpi4py.Comm object
             partitioner: cubed sphere partitioner
@@ -446,7 +449,10 @@ class CubedSphereCommunicator(Communicator):
         )
 
     def vector_halo_update(
-        self, x_quantity: Quantity, y_quantity: Quantity, n_points: int,
+        self,
+        x_quantity: Quantity,
+        y_quantity: Quantity,
+        n_points: int,
     ):
         """Perform a halo update of a horizontal vector quantity.
 
@@ -477,7 +483,7 @@ class CubedSphereCommunicator(Communicator):
         Args:
             x_quantity: the x-component quantity to be synchronized
             y_quantity: the y-component quantity to be synchronized
-        
+
         Returns:
             request: an asynchronous request object with a .wait() method
         """
@@ -512,7 +518,10 @@ class CubedSphereCommunicator(Communicator):
         req.wait()
 
     def start_vector_halo_update(
-        self, x_quantity: Quantity, y_quantity: Quantity, n_points: int,
+        self,
+        x_quantity: Quantity,
+        y_quantity: Quantity,
+        n_points: int,
     ) -> HaloUpdateRequest:
         """Start an asynchronous halo update of a horizontal vector quantity.
 
@@ -640,7 +649,9 @@ class CubedSphereCommunicator(Communicator):
         # don't want to use a buffer here, because we leave this scope and can't close
         # the context manager. might figure out a way to do it later
         with self.timer.clock("pack"):
-            array = np.ascontiguousarray(numpy.asnumpy(in_array))
+            array = np.ascontiguousarray(
+                numpy.asnumpy(in_array) if hasattr(numpy, "asnumpy") else in_array
+            )
         with self.timer.clock("Isend"):
             return self.comm.Isend(array, **kwargs)
 
@@ -665,7 +676,10 @@ class CubedSphereCommunicator(Communicator):
         return FunctionRequest(recv)
 
     def finish_vector_halo_update(
-        self, x_quantity: Quantity, y_quantity: Quantity, n_points: int,
+        self,
+        x_quantity: Quantity,
+        y_quantity: Quantity,
+        n_points: int,
     ):
         """Deprecated, do not use."""
         raise NotImplementedError(

--- a/fv3gfs/util/testing/dummy_comm.py
+++ b/fv3gfs/util/testing/dummy_comm.py
@@ -20,6 +20,7 @@ class AsyncResult:
     def wait(self):
         return self._result()
 
+
 class DummyComm:
     def __init__(self, rank, total_ranks, buffer_dict):
         self.rank = rank

--- a/fv3gfs/util/testing/dummy_comm.py
+++ b/fv3gfs/util/testing/dummy_comm.py
@@ -1,6 +1,6 @@
 import logging
 import copy
-from ..utils import ensure_contiguous
+from ..utils import assign_array, ensure_contiguous
 
 
 logger = logging.getLogger("fv3gfs.util")
@@ -19,7 +19,6 @@ class AsyncResult:
 
     def wait(self):
         return self._result()
-
 
 class DummyComm:
     def __init__(self, rank, total_ranks, buffer_dict):
@@ -109,7 +108,7 @@ class DummyComm:
             sendbuf = self._get_buffer("scatter", copy.deepcopy(sendbuf))
         else:
             sendbuf = self._get_buffer("scatter", None)
-        recvbuf[:] = sendbuf[self.rank]
+        assign_array(recvbuf, sendbuf[self.rank])
 
     def Gather(self, sendbuf, recvbuf, root=0, **kwargs):
         ensure_contiguous(sendbuf)
@@ -126,7 +125,7 @@ class DummyComm:
                     f"gather called on root rank before ranks {uncalled_ranks}"
                 )
             for i, sendbuf in enumerate(gather_buffer):
-                recvbuf[i, :] = sendbuf
+                assign_array(recvbuf[i, :], sendbuf)
 
     def Send(self, sendbuf, dest, **kwargs):
         ensure_contiguous(sendbuf)
@@ -142,7 +141,7 @@ class DummyComm:
 
     def Recv(self, recvbuf, source, **kwargs):
         ensure_contiguous(recvbuf)
-        recvbuf[:] = self._get_send_recv(source)
+        assign_array(recvbuf, self._get_send_recv(source))
 
     def Irecv(self, recvbuf, source, **kwargs):
         def receive():

--- a/fv3gfs/util/utils.py
+++ b/fv3gfs/util/utils.py
@@ -58,15 +58,15 @@ def ensure_contiguous(maybe_array: Union[np.ndarray, Storage]) -> None:
 
 
 def assign_array(
-    left_array: Union[np.ndarray, Storage], right_array: Union[np.ndarray, Storage],
+    to_array: Union[np.ndarray, Storage], from_array: Union[np.ndarray, Storage],
 ):
     # The cp.asarray call is required to explicitly copy the data
     # in the case of numpy arrays or to prevent memory ownership
     # errors on the cupy arrays from gt4py storages.
     # This should be fixed in a later version of gt4py
-    if cp and isinstance(left_array, cp.ndarray):
-        left_array[:] = cp.asarray(right_array)
-    elif cp and isinstance(right_array, cp.ndarray):
-        left_array[:] = cp.asnumpy(right_array)
+    if cp and isinstance(to_array, cp.ndarray):
+        to_array[:] = cp.asarray(from_array)
+    elif cp and isinstance(from_array, cp.ndarray):
+        to_array[:] = cp.asnumpy(from_array)
     else:
-        left_array[:] = right_array
+        to_array[:] = from_array

--- a/fv3gfs/util/utils.py
+++ b/fv3gfs/util/utils.py
@@ -58,8 +58,7 @@ def ensure_contiguous(maybe_array: Union[np.ndarray, Storage]) -> None:
 
 
 def assign_array(
-    left_array: Union[np.ndarray, Storage],
-    right_array: Union[np.ndarray, Storage],
+    left_array: Union[np.ndarray, Storage], right_array: Union[np.ndarray, Storage],
 ):
     # The cp.asarray call is required to explicitly copy the data
     # in the case of numpy arrays or to prevent memory ownership

--- a/fv3gfs/util/utils.py
+++ b/fv3gfs/util/utils.py
@@ -58,8 +58,8 @@ def ensure_contiguous(maybe_array: Union[np.ndarray, Storage]) -> None:
 
 
 def assign_array(
-    left_array: Union[np.ndarray, cp.ndarray],
-    right_array: Union[np.ndarray, cp.ndarray],
+    left_array: Union[np.ndarray, Storage],
+    right_array: Union[np.ndarray, Storage],
 ):
     # The cp.asarray call is required to explicitly copy the data
     # in the case of numpy arrays or to prevent memory ownership

--- a/fv3gfs/util/utils.py
+++ b/fv3gfs/util/utils.py
@@ -3,6 +3,11 @@ from . import constants
 import numpy as np
 
 try:
+    import cupy as cp
+except ModuleNotFoundError:
+    cp = None
+
+try:
     from gt4py.storage.storage import Storage
 except ImportError:
 
@@ -50,3 +55,19 @@ def is_c_contiguous(array: Union[np.ndarray, Storage]) -> bool:
 def ensure_contiguous(maybe_array: Union[np.ndarray, Storage]) -> None:
     if isinstance(maybe_array, np.ndarray) and not is_contiguous(maybe_array):
         raise ValueError("ndarray is not contiguous")
+
+
+def assign_array(
+    left_array: Union[np.ndarray, cp.ndarray],
+    right_array: Union[np.ndarray, cp.ndarray],
+):
+    # The cp.asarray call is required to explicitly copy the data
+    # in the case of numpy arrays or to prevent memory ownership
+    # errors on the cupy arrays from gt4py storages.
+    # This should be fixed in a later version of gt4py
+    if cp and isinstance(left_array, cp.ndarray):
+        left_array[:] = cp.asarray(right_array)
+    elif cp and isinstance(right_array, cp.ndarray):
+        left_array[:] = cp.asnumpy(right_array)
+    else:
+        left_array[:] = right_array

--- a/tests/mpi/test_mpi_halo_update.py
+++ b/tests/mpi/test_mpi_halo_update.py
@@ -245,7 +245,8 @@ def depth_quantity(
 ):
     """A quantity whose value indicates the distance from the computational
     domain boundary."""
-    data = numpy.zeros(shape, dtype=dtype) + numpy.nan
+    data = numpy.zeros(shape, dtype=dtype)
+    data[:] = numpy.nan
     for n_inside in range(max(n_points, max(extent) // 2), -1, -1):
         for i, dim in enumerate(dims):
             if (n_inside <= extent[i] // 2) and (dim in fv3gfs.util.HORIZONTAL_DIMS):


### PR DESCRIPTION
This PR makes some (admittedly somewhat hacky) fixes to the `feature/gpu_halo_update_on_cpu` to get the halo exchange tests passing on Piz Daint.

```bash
srun --partition=debug --account=s1053 -N 6 -C gpu pytest -vv -s tests/mpi/test_mpi_halo_update.py --gpu-only
srun: job 28729408 queued and waiting for resources
srun: job 28729408 has been allocated resources
...
======================= 216 passed, 360 skipped in 6.42s =======================
tests/mpi/test_mpi_halo_update.py::test_zeros_vector_halo_update[same-3-interface_3d-gt4py_cupy-1] PASSED

======================= 216 passed, 360 skipped in 6.47s =======================
tests/mpi/test_mpi_halo_update.py::test_zeros_vector_halo_update[same-3-interface_3d-gt4py_cupy-1] PASSED

======================= 216 passed, 360 skipped in 6.03s =======================
tests/mpi/test_mpi_halo_update.py::test_zeros_vector_halo_update[same-3-interface_3d-gt4py_cupy-1] PASSED

======================= 216 passed, 360 skipped in 6.49s =======================
tests/mpi/test_mpi_halo_update.py::test_zeros_vector_halo_update[same-3-interface_3d-gt4py_cupy-1] PASSED

======================= 216 passed, 360 skipped in 6.49s =======================
tests/mpi/test_mpi_halo_update.py::test_zeros_vector_halo_update[same-3-interface_3d-gt4py_cupy-1] PASSED

======================= 216 passed, 360 skipped in 6.50s =======================

```