### PR TITLE
Allow scatter_state to work without a 'time' key

### DIFF
--- a/fv3gfs/util/communicator.py
+++ b/fv3gfs/util/communicator.py
@@ -269,9 +269,7 @@ class Communicator:
                     self.scatter(recv_quantity=recv_state[name])
                 else:
                     recv_state[name] = self.scatter()
-            time = self.comm.bcast(None, root=constants.ROOT_RANK)
-            if time is not None:
-                recv_state["time"] = time
+            recv_state["time"] = self.comm.bcast(None, root=constants.ROOT_RANK)
 
         if recv_state is None:
             recv_state = {}

--- a/tests/test_tile_scatter_gather.py
+++ b/tests/test_tile_scatter_gather.py
@@ -312,6 +312,24 @@ def test_tile_scatter_state(
         scattered.np.testing.assert_array_equal(result.view[:], scattered.view[:])
 
 
+def test_tile_scatter_state_without_time(
+    tile_quantity, scattered_quantities, communicator_list
+):
+    state = {"air_temperature": tile_quantity}
+    result_list = []
+    for communicator in communicator_list:
+        if communicator.rank == 0:
+            result_list.append(communicator.scatter_state(send_state=state))
+        else:
+            result_list.append(communicator.scatter_state())
+    for result_state, scattered in zip(result_list, scattered_quantities):
+        result = result_state["air_temperature"]
+        assert result.dims == scattered.dims
+        assert result.units == scattered.units
+        assert result.extent == scattered.extent
+        scattered.np.testing.assert_array_equal(result.view[:], scattered.view[:])
+
+
 def test_tile_scatter_state_with_recv_state(
     tile_quantity, scattered_quantities, communicator_list, time
 ):

--- a/tests/test_tile_scatter_gather.py
+++ b/tests/test_tile_scatter_gather.py
@@ -323,6 +323,7 @@ def test_tile_scatter_state_without_time(
         else:
             result_list.append(communicator.scatter_state())
     for result_state, scattered in zip(result_list, scattered_quantities):
+        assert "time" not in result_state
         result = result_state["air_temperature"]
         assert result.dims == scattered.dims
         assert result.units == scattered.units
@@ -373,6 +374,7 @@ def test_tile_scatter_state_with_recv_state_without_time(
         else:
             result = communicator.scatter_state(recv_state=state)
         assert result["air_temperature"] is recv
+        assert "time" not in result
     for rank, (result, scattered) in enumerate(
         zip(recv_quantities, scattered_quantities)
     ):

--- a/tests/test_tile_scatter_gather.py
+++ b/tests/test_tile_scatter_gather.py
@@ -355,3 +355,28 @@ def test_tile_scatter_state_with_recv_state(
         assert result.units == scattered.units
         assert result.extent == scattered.extent
         scattered.np.testing.assert_array_equal(result.view[:], scattered.view[:])
+
+
+def test_tile_scatter_state_with_recv_state_without_time(
+    tile_quantity, scattered_quantities, communicator_list
+):
+    tile_state = {"air_temperature": tile_quantity}
+    recv_quantities = copy.deepcopy(scattered_quantities)
+    for q in recv_quantities:
+        q.data[:] = 0.0
+    for recv, communicator in zip(recv_quantities, communicator_list):
+        state = {
+            "air_temperature": recv,
+        }
+        if communicator.rank == 0:
+            result = communicator.scatter_state(send_state=tile_state, recv_state=state)
+        else:
+            result = communicator.scatter_state(recv_state=state)
+        assert result["air_temperature"] is recv
+    for rank, (result, scattered) in enumerate(
+        zip(recv_quantities, scattered_quantities)
+    ):
+        assert result.dims == scattered.dims
+        assert result.units == scattered.units
+        assert result.extent == scattered.extent
+        scattered.np.testing.assert_array_equal(result.view[:], scattered.view[:])


### PR DESCRIPTION
As I understand things, this should fix #44.  

Currently, if a `"time"` key does not appear in the state to be scattered, `scatter_state` will fail, because a `"time"` key will not exist in the `recv_state` of the non-root processes.  This ensures that if a `"time"` key does not exist in the state to be scattered, it will be filled with `None` in the non-root processes, and then removed at the end.

This was the minimal solution as far as I could tell.  I'm open to other ideas for how to fix this, however.