### PR TITLE
Addition of hitcount to timer

### DIFF
--- a/fv3gfs/util/_timing.py
+++ b/fv3gfs/util/_timing.py
@@ -10,6 +10,7 @@ class Timer:
     def __init__(self):
         self._clock_starts = {}
         self._accumulated_time = {}
+        self._hit_count = {}
         self._enabled = True
 
     def start(self, name: str):
@@ -21,14 +22,18 @@ class Timer:
                 self._clock_starts[name] = time()
 
     def stop(self, name: str):
-        """Stop timing a given named operation, and add the time elapsed to
-        accumulated timing.
+        """Stop timing a given named operation, add the time elapsed to
+        accumulated timing and increase the hit count.
         """
         if self._enabled:
             if name not in self._accumulated_time:
                 self._accumulated_time[name] = time() - self._clock_starts.pop(name)
             else:
                 self._accumulated_time[name] += time() - self._clock_starts.pop(name)
+            if name not in self._hit_count:
+                self._hit_count[name] = 1
+            else:
+                self._hit_count[name] += 1
 
     @contextlib.contextmanager
     def clock(self, name: str):
@@ -66,9 +71,22 @@ class Timer:
             )
         return self._accumulated_time.copy()
 
+    @property
+    def hitcounts(self) -> Mapping[str, int]:
+        """accumulated hit counts for each operation name"""
+        if len(self._clock_starts) > 0:
+            warnings.warn(
+                "Retrieved hit counts while clocks are still going, "
+                "incomplete times are not included: "
+                f"{list(self._clock_starts.keys())}",
+                RuntimeWarning,
+            )
+        return self._hit_count.copy()
+
     def reset(self):
         """Remove all accumulated timings."""
         self._accumulated_time.clear()
+        self._hit_count.clear()
 
     def enable(self):
         """Enable the Timer."""

--- a/fv3gfs/util/_timing.py
+++ b/fv3gfs/util/_timing.py
@@ -72,7 +72,7 @@ class Timer:
         return self._accumulated_time.copy()
 
     @property
-    def hitcounts(self) -> Mapping[str, int]:
+    def hits(self) -> Mapping[str, int]:
         """accumulated hit counts for each operation name"""
         if len(self._clock_starts) > 0:
             warnings.warn(

--- a/tests/test_timer.py
+++ b/tests/test_timer.py
@@ -14,6 +14,8 @@ def test_start_stop(timer):
     times = timer.times
     assert "label" in times
     assert len(times) == 1
+    assert timer.hitcounts["label"] == 1
+    assert len(timer.hitcounts) == 1
 
 
 def test_clock(timer):
@@ -24,6 +26,8 @@ def test_clock(timer):
     assert "label" in times
     assert len(times) == 1
     assert abs(times["label"] - 0.1) < 1e-2
+    assert timer.hitcounts["label"] == 1
+    assert len(timer.hitcounts) == 1
 
 
 def test_start_twice(timer):
@@ -55,6 +59,7 @@ def test_consecutive_start_stops(timer):
         timer.stop("label")
         assert timer.times["label"] >= previous_time + 0.01
         previous_time = timer.times["label"]
+    assert timer.hitcounts["label"] == 6
 
 
 def test_consecutive_clocks(timer):
@@ -67,6 +72,7 @@ def test_consecutive_clocks(timer):
             time.sleep(0.01)
         assert timer.times["label"] >= previous_time + 0.01
         previous_time = timer.times["label"]
+    assert timer.hitcounts["label"] == 6
 
 
 @pytest.mark.parametrize(
@@ -93,6 +99,7 @@ def test_disabled_timer_does_not_add_key(timer):
     with timer.clock("label2"):
         time.sleep(0.01)
     assert len(timer.times) == 0
+    assert len(timer.hitcounts) == 0
 
 
 def test_disabled_timer_does_not_add_time(timer):
@@ -103,6 +110,7 @@ def test_disabled_timer_does_not_add_time(timer):
     with timer.clock("label"):
         time.sleep(0.01)
     assert timer.times["label"] == initial_time
+    assert timer.hitcounts["label"] == 1
 
 
 @pytest.fixture(params=["clean", "one_label", "two_labels"])
@@ -124,3 +132,4 @@ def used_timer(request, timer):
 def test_timer_reset(used_timer):
     used_timer.reset()
     assert len(used_timer.times) == 0
+    assert len(used_timer.hitcounts) == 0

--- a/tests/test_timer.py
+++ b/tests/test_timer.py
@@ -14,8 +14,8 @@ def test_start_stop(timer):
     times = timer.times
     assert "label" in times
     assert len(times) == 1
-    assert timer.hitcounts["label"] == 1
-    assert len(timer.hitcounts) == 1
+    assert timer.hits["label"] == 1
+    assert len(timer.hits) == 1
 
 
 def test_clock(timer):
@@ -26,8 +26,8 @@ def test_clock(timer):
     assert "label" in times
     assert len(times) == 1
     assert abs(times["label"] - 0.1) < 1e-2
-    assert timer.hitcounts["label"] == 1
-    assert len(timer.hitcounts) == 1
+    assert timer.hits["label"] == 1
+    assert len(timer.hits) == 1
 
 
 def test_start_twice(timer):
@@ -59,7 +59,7 @@ def test_consecutive_start_stops(timer):
         timer.stop("label")
         assert timer.times["label"] >= previous_time + 0.01
         previous_time = timer.times["label"]
-    assert timer.hitcounts["label"] == 6
+    assert timer.hits["label"] == 6
 
 
 def test_consecutive_clocks(timer):
@@ -72,7 +72,7 @@ def test_consecutive_clocks(timer):
             time.sleep(0.01)
         assert timer.times["label"] >= previous_time + 0.01
         previous_time = timer.times["label"]
-    assert timer.hitcounts["label"] == 6
+    assert timer.hits["label"] == 6
 
 
 @pytest.mark.parametrize(
@@ -99,7 +99,7 @@ def test_disabled_timer_does_not_add_key(timer):
     with timer.clock("label2"):
         time.sleep(0.01)
     assert len(timer.times) == 0
-    assert len(timer.hitcounts) == 0
+    assert len(timer.hits) == 0
 
 
 def test_disabled_timer_does_not_add_time(timer):
@@ -110,7 +110,7 @@ def test_disabled_timer_does_not_add_time(timer):
     with timer.clock("label"):
         time.sleep(0.01)
     assert timer.times["label"] == initial_time
-    assert timer.hitcounts["label"] == 1
+    assert timer.hits["label"] == 1
 
 
 @pytest.fixture(params=["clean", "one_label", "two_labels"])
@@ -132,4 +132,4 @@ def used_timer(request, timer):
 def test_timer_reset(used_timer):
     used_timer.reset()
     assert len(used_timer.times) == 0
-    assert len(used_timer.hitcounts) == 0
+    assert len(used_timer.hits) == 0


### PR DESCRIPTION
## Major changes
- This adds a hit-count to the timer that counts how often each timer is called. The main use for this are sanity checks - specifically comparing Fortran to python code. 