### PR TITLE
Public NullTimer

### DIFF
--- a/fv3gfs/util/__init__.py
+++ b/fv3gfs/util/__init__.py
@@ -10,7 +10,7 @@ from .partitioner import (
     get_tile_index,
     get_tile_number,
 )
-from ._timing import Timer
+from ._timing import Timer, NullTimer
 from .constants import (
     ROOT_RANK,
     X_DIM,


### PR DESCRIPTION
NullTimer is very useful externally as a default timer value, and should be made public.