### PR TITLE
Fix setup.py and test it with tox in Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,7 @@ jobs:
           command: |
             sudo apt-get update
             sudo apt-get install libopenmpi3
+            sudo pip3 install tox
 
       # Download and cache dependencies
       # - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,24 +24,6 @@ jobs:
             sudo apt-get update
             sudo apt-get install libopenmpi3
             sudo pip3 install tox
-
-      # Download and cache dependencies
-      # - restore_cache:
-      #     keys:
-      #       - v1-dependencies-{{ checksum "requirements.txt" }}
-      #       # fallback to using the latest cache if no exact match is found
-      #       - v1-dependencies-
-      # - run:
-      #     name: install dependencies
-      #     command: |
-      #       python3 -m venv venv
-      #       . venv/bin/activate
-      #       pip3 install -r requirements.txt
-      #       pip3 install mpi4py==3.0.3
-      # - save_cache:
-      #     paths:
-      #       - ./.tox
-      #     key: v1-dependencies-{{ checksum "requirements.txt" }}
       - run:
           name: run tests
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,10 +24,22 @@ jobs:
             sudo apt-get update
             sudo apt-get install libopenmpi3
             sudo pip3 install tox
+
+      # Download and cache dependencies
+      - run: cat tox.ini setup.py > checksum-me
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "checksum-me" }}
+            # fallback to using the latest cache if no exact match is found
+            - v1-dependencies-
       - run:
           name: run tests
           command: |
             tox
+      - save_cache:
+          paths:
+            - ./.tox
+          key: v1-dependencies-{{ checksum "checksum-me" }}
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,8 +8,8 @@ jobs:
     - image: circleci/python:3.7
     steps:
       - checkout
-      - run: sudo pip3 install black==19.10b0 flake8==3.8.4 mypy==0.790
-      - run: make lint
+      - run: sudo pip3 install tox
+      - run: tox -e lint
 
   test_python:
     docker:
@@ -25,28 +25,26 @@ jobs:
             sudo apt-get install libopenmpi3
 
       # Download and cache dependencies
-      - restore_cache:
-          keys:
-            - v1-dependencies-{{ checksum "requirements.txt" }}
-            # fallback to using the latest cache if no exact match is found
-            - v1-dependencies-
-      - run:
-          name: install dependencies
-          command: |
-            python3 -m venv venv
-            . venv/bin/activate
-            pip3 install -r requirements.txt
-            pip3 install mpi4py==3.0.3
-      - save_cache:
-          paths:
-            - ./venv
-          key: v1-dependencies-{{ checksum "requirements.txt" }}
+      # - restore_cache:
+      #     keys:
+      #       - v1-dependencies-{{ checksum "requirements.txt" }}
+      #       # fallback to using the latest cache if no exact match is found
+      #       - v1-dependencies-
+      # - run:
+      #     name: install dependencies
+      #     command: |
+      #       python3 -m venv venv
+      #       . venv/bin/activate
+      #       pip3 install -r requirements.txt
+      #       pip3 install mpi4py==3.0.3
+      # - save_cache:
+      #     paths:
+      #       - ./.tox
+      #     key: v1-dependencies-{{ checksum "requirements.txt" }}
       - run:
           name: run tests
           command: |
-            . venv/bin/activate
-            pip3 install .
-            make test test_mpi
+            tox
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,22 +24,11 @@ jobs:
             sudo apt-get update
             sudo apt-get install libopenmpi3
             sudo pip3 install tox
-
-      # Download and cache dependencies
-      - run: cat tox.ini setup.py > checksum-me
-      - restore_cache:
-          keys:
-            - v1-dependencies-{{ checksum "checksum-me" }}
-            # fallback to using the latest cache if no exact match is found
-            - v1-dependencies-
       - run:
           name: run tests
           command: |
             tox
-      - save_cache:
-          paths:
-            - ./.tox
-          key: v1-dependencies-{{ checksum "checksum-me" }}
+
 
 workflows:
   version: 2

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include LICENSE
 include README.md
+include HISTORY.md
 
 recursive-include fv3gfs *.json *.yml
 recursive-include tests *.py *.sh

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,8 @@ requirements = [
     "fsspec>=0.6.0",
     "zarr>=2.3.2",
     "typing_extensions>=3.7.4",
+    "scipy>=1.6.0",
+    "mpi4py>=3.0.3",
 ]
 if sys.version_info.major == 3 and sys.version_info.minor == 6:
     requirements.append("dataclasses")

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ requirements = [
     "fsspec>=0.6.0",
     "zarr>=2.3.2",
     "typing_extensions>=3.7.4",
-    "scipy>=1.6.0",
+    "scipy>=1.3.1",
 ]
 if sys.version_info.major == 3 and sys.version_info.minor == 6:
     requirements.append("dataclasses")

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,6 @@ requirements = [
     "zarr>=2.3.2",
     "typing_extensions>=3.7.4",
     "scipy>=1.6.0",
-    "mpi4py>=3.0.3",
 ]
 if sys.version_info.major == 3 and sys.version_info.minor == 6:
     requirements.append("dataclasses")

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ requirements = [
     "numpy>=0.15.0",
     "fsspec>=0.6.0",
     "zarr>=2.3.2",
+    "typing_extensions>=3.7.4",
 ]
 if sys.version_info.major == 3 and sys.version_info.minor == 6:
     requirements.append("dataclasses")

--- a/tox.ini
+++ b/tox.ini
@@ -7,16 +7,19 @@
 envlist = py3
 
 [testenv]
+allowlist_externals=make mpirun
 deps =
     # other versions of pytest don't work with subtests
     pytest == 5.2.2
     pytest-subtests==0.3.0
     pytest-cov==2.8.1
     git+https://github.com/GridTools/gt4py.git@db40777788863bfe87b9674b118e8bd5b8db0440#egg=gt4py
+    mpi4py==3.0.3
 commands =
     make test test_mpi
 
 [testenv:lint]
+allowlist_externals=make
 skip_install = true
 deps = 
     black==19.10b0

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,6 @@ deps =
     git+https://github.com/GridTools/gt4py.git@db40777788863bfe87b9674b118e8bd5b8db0440#egg=gt4py
 commands =
     make test test_mpi
-    pytest {posargs}
 
 [testenv:lint]
 skip_install = true

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,13 @@
+# tox (https://tox.readthedocs.io/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist = py3
+
+[testenv]
+deps =
+    pytest
+commands =
+    pytest

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,6 @@ envlist = py3
 [testenv]
 allowlist_externals=make mpirun
 deps =
-    -c requirements.txt
     # other versions of pytest don't work with subtests
     pytest == 5.2.2
     pytest-subtests==0.3.0

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ envlist = py3
 [testenv]
 allowlist_externals=make mpirun
 deps =
+    -c requirements.txt
     # other versions of pytest don't work with subtests
     pytest == 5.2.2
     pytest-subtests==0.3.0

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,20 @@ envlist = py3
 
 [testenv]
 deps =
-    pytest
+    # other versions of pytest don't work with subtests
+    pytest == 5.2.2
+    pytest-subtests==0.3.0
+    pytest-cov==2.8.1
+    git+https://github.com/GridTools/gt4py.git@db40777788863bfe87b9674b118e8bd5b8db0440#egg=gt4py
 commands =
-    pytest
+    make test test_mpi
+    pytest {posargs}
+
+[testenv:lint]
+skip_install = true
+deps = 
+    black==19.10b0
+    flake8==3.8.4
+    mypy==0.790
+commands = 
+    make lint


### PR DESCRIPTION
Currently the setup.py file is missing some dependencies and refers to files not in `MANIFEST.in` which sometimes prevent this package from being `pip installed`.  This will make it hard to distribute this package via PyPi. These errors appeared because the code in`setup.py` is not actually being tested.

This PR adds the missing requirements (scipy and mpi4py) to the setup.py and tests it with [tox](https://tox.readthedocs.io/en/latest/). Tox is a widely used tool for testing python projects in isolated virtual environments and ensuring that the `setup.py` actually works. Another advantage is that it moves testing code out of the circle/config.yml and allows the local developer to trigger the tests identically to the CI.

~~The build time increased because tox now runs many thousands of more tests than before.~~

Other changes:
- removed caching logic from CircleCI. This caching logic would have to change for tox, and the environment install only takes about 1 minute, so it's probably not worth the complexity to optimize this portion of the build. This probably changed when `numcodecs` started uploading wheels.

Edit: I fixed this in 031eee4