### PR TITLE
Change layout order to x,y in tests

### DIFF
--- a/tests/mpi/test_mpi_halo_update.py
+++ b/tests/mpi/test_mpi_halo_update.py
@@ -37,12 +37,12 @@ def nz():
 
 @pytest.fixture
 def ny(ny_rank, layout):
-    return ny_rank * layout[0]
+    return ny_rank * layout[1]
 
 
 @pytest.fixture
 def nx(nx_rank, layout):
-    return nx_rank * layout[1]
+    return nx_rank * layout[0]
 
 
 @pytest.fixture(params=[1, 3])

--- a/tests/test_cube_scatter_gather.py
+++ b/tests/test_cube_scatter_gather.py
@@ -69,10 +69,10 @@ def assert_quantity_equals(result, reference):
 @pytest.fixture()
 def dim_lengths(layout):
     return {
-        fv3gfs.util.X_DIM: 2 * layout[1],
-        fv3gfs.util.X_INTERFACE_DIM: 2 * layout[1] + 1,
-        fv3gfs.util.Y_DIM: 2 * layout[0],
-        fv3gfs.util.Y_INTERFACE_DIM: 2 * layout[0] + 1,
+        fv3gfs.util.X_DIM: 2 * layout[0],
+        fv3gfs.util.X_INTERFACE_DIM: 2 * layout[0] + 1,
+        fv3gfs.util.Y_DIM: 2 * layout[1],
+        fv3gfs.util.Y_INTERFACE_DIM: 2 * layout[1] + 1,
         fv3gfs.util.Z_DIM: 3,
         fv3gfs.util.Z_INTERFACE_DIM: 4,
     }

--- a/tests/test_dimension_sizer.py
+++ b/tests/test_dimension_sizer.py
@@ -24,12 +24,12 @@ def nz(request, fast):
 
 @pytest.fixture
 def nx(nx_tile, layout):
-    return nx_tile / layout[1]
+    return nx_tile / layout[0]
 
 
 @pytest.fixture
 def ny(ny_tile, layout):
-    return ny_tile / layout[0]
+    return ny_tile / layout[1]
 
 
 @pytest.fixture(params=[(1, 1), (3, 3)])

--- a/tests/test_halo_update.py
+++ b/tests/test_halo_update.py
@@ -33,12 +33,12 @@ def nz():
 
 @pytest.fixture
 def ny(ny_rank, layout):
-    return ny_rank * layout[0]
+    return ny_rank * layout[1]
 
 
 @pytest.fixture
 def nx(nx_rank, layout):
-    return nx_rank * layout[1]
+    return nx_rank * layout[0]
 
 
 @pytest.fixture(params=[1, 3])

--- a/tests/test_legacy_restart.py
+++ b/tests/test_legacy_restart.py
@@ -49,8 +49,8 @@ def test_open_c12_restart(layout):
         layout, only_names, tracer_properties
     )
     # C12 has 12 gridcells along each tile side, we divide this across processors
-    ny = 12 / layout[0]
-    nx = 12 / layout[1]
+    ny = 12 / layout[1]
+    nx = 12 / layout[0]
     for state in c12_restart_state_list:
         assert "time" in state.keys()
         assert len(state.keys()) == 63
@@ -127,8 +127,8 @@ def test_open_c12_restart_tracer_properties(layout, tracer_properties):
 @pytest.mark.cpu_only
 def test_open_c12_restart_empty_to_state_without_crashing(layout):
     total_ranks = layout[0] * layout[1]
-    ny = 12 / layout[0]
-    nx = 12 / layout[1]
+    ny = 12 / layout[1]
+    nx = 12 / layout[0]
     shared_buffer = {}
     communicator_list = []
     for rank in range(total_ranks):
@@ -169,8 +169,8 @@ def test_open_c12_restart_empty_to_state_without_crashing(layout):
 @pytest.mark.cpu_only
 def test_open_c12_restart_to_allocated_state_without_crashing(layout):
     total_ranks = layout[0] * layout[1]
-    ny = 12 / layout[0]
-    nx = 12 / layout[1]
+    ny = 12 / layout[1]
+    nx = 12 / layout[0]
     shared_buffer = {}
     communicator_list = []
     for rank in range(total_ranks):

--- a/tests/test_partitioner.py
+++ b/tests/test_partitioner.py
@@ -48,8 +48,8 @@ subtile_index_list = []
 for layout in ((1, 1), (1, 2), (2, 2), (2, 3)):
     rank = 0
     for tile in range(6):
-        for y_subtile in range(layout[0]):
-            for x_subtile in range(layout[1]):
+        for x_subtile in range(layout[0]):
+            for y_subtile in range(layout[1]):
                 rank_list.append(rank)
                 layout_list.append(layout)
                 subtile_index_list.append((y_subtile, x_subtile))

--- a/tests/test_tile_scatter.py
+++ b/tests/test_tile_scatter.py
@@ -32,19 +32,19 @@ def get_tile_communicator_list(partitioner):
 def test_interface_state_two_by_two_per_rank_scatter_tile(layout, numpy):
     state = {
         "pos_j": fv3gfs.util.Quantity(
-            numpy.empty([layout[0] + 1, layout[1] + 1]),
+            numpy.empty([layout[1] + 1, layout[0] + 1]),
             dims=[fv3gfs.util.Y_INTERFACE_DIM, fv3gfs.util.X_INTERFACE_DIM],
             units="dimensionless",
         ),
         "pos_i": fv3gfs.util.Quantity(
-            numpy.empty([layout[0] + 1, layout[1] + 1], dtype=numpy.int32),
+            numpy.empty([layout[1] + 1, layout[0] + 1], dtype=numpy.int32),
             dims=[fv3gfs.util.Y_INTERFACE_DIM, fv3gfs.util.X_INTERFACE_DIM],
             units="dimensionless",
         ),
     }
 
-    state["pos_j"].view[:, :] = numpy.arange(0, layout[0] + 1)[:, None]
-    state["pos_i"].view[:, :] = numpy.arange(0, layout[1] + 1)[None, :]
+    state["pos_j"].view[:, :] = numpy.arange(0, layout[1] + 1)[:, None]
+    state["pos_i"].view[:, :] = numpy.arange(0, layout[0] + 1)[None, :]
 
     partitioner = fv3gfs.util.TilePartitioner(layout)
     tile_communicator_list = get_tile_communicator_list(partitioner)
@@ -76,17 +76,17 @@ def test_centered_state_one_item_per_rank_scatter_tile(layout, numpy):
     total_ranks = layout[0] * layout[1]
     state = {
         "rank": fv3gfs.util.Quantity(
-            numpy.empty([layout[0], layout[1]]),
+            numpy.empty([layout[1], layout[0]]),
             dims=[fv3gfs.util.Y_DIM, fv3gfs.util.X_DIM],
             units="dimensionless",
         ),
         "rank_pos_j": fv3gfs.util.Quantity(
-            numpy.empty([layout[0], layout[1]]),
+            numpy.empty([layout[1], layout[0]]),
             dims=[fv3gfs.util.Y_DIM, fv3gfs.util.X_DIM],
             units="dimensionless",
         ),
         "rank_pos_i": fv3gfs.util.Quantity(
-            numpy.empty([layout[0], layout[1]]),
+            numpy.empty([layout[1], layout[0]]),
             dims=[fv3gfs.util.Y_DIM, fv3gfs.util.X_DIM],
             units="dimensionless",
         ),
@@ -131,21 +131,21 @@ def test_centered_state_one_item_per_rank_with_halo_scatter_tile(layout, n_halo,
     total_ranks = layout[0] * layout[1]
     state = {
         "rank": fv3gfs.util.Quantity(
-            numpy.empty([layout[0] + 2 * n_halo, layout[1] + 2 * n_halo]),
+            numpy.empty([layout[1] + 2 * n_halo, layout[0] + 2 * n_halo]),
             dims=[fv3gfs.util.Y_DIM, fv3gfs.util.X_DIM],
             units="dimensionless",
             origin=(n_halo, n_halo),
             extent=extent,
         ),
         "rank_pos_j": fv3gfs.util.Quantity(
-            numpy.empty([layout[0] + 2 * n_halo, layout[1] + 2 * n_halo]),
+            numpy.empty([layout[1] + 2 * n_halo, layout[0] + 2 * n_halo]),
             dims=[fv3gfs.util.Y_DIM, fv3gfs.util.X_DIM],
             units="dimensionless",
             origin=(n_halo, n_halo),
             extent=extent,
         ),
         "rank_pos_i": fv3gfs.util.Quantity(
-            numpy.empty([layout[0] + 2 * n_halo, layout[1] + 2 * n_halo]),
+            numpy.empty([layout[1] + 2 * n_halo, layout[0] + 2 * n_halo]),
             dims=[fv3gfs.util.Y_DIM, fv3gfs.util.X_DIM],
             units="dimensionless",
             origin=(n_halo, n_halo),

--- a/tests/test_tile_scatter_gather.py
+++ b/tests/test_tile_scatter_gather.py
@@ -61,10 +61,10 @@ def time():
 @pytest.fixture()
 def dim_lengths(layout):
     return {
-        fv3gfs.util.X_DIM: 2 * layout[1],
-        fv3gfs.util.X_INTERFACE_DIM: 2 * layout[1] + 1,
-        fv3gfs.util.Y_DIM: 2 * layout[0],
-        fv3gfs.util.Y_INTERFACE_DIM: 2 * layout[0] + 1,
+        fv3gfs.util.X_DIM: 2 * layout[0],
+        fv3gfs.util.X_INTERFACE_DIM: 2 * layout[0] + 1,
+        fv3gfs.util.Y_DIM: 2 * layout[1],
+        fv3gfs.util.Y_INTERFACE_DIM: 2 * layout[1] + 1,
         fv3gfs.util.Z_DIM: 3,
         fv3gfs.util.Z_INTERFACE_DIM: 4,
     }

--- a/tests/test_zarr_monitor.py
+++ b/tests/test_zarr_monitor.py
@@ -189,8 +189,8 @@ def test_monitor_file_store_multi_rank_state(
     units = "m"
     tmpdir = tmpdir_factory.mktemp("data.zarr")
     nz, ny, nx = shape
-    ny_rank = int(ny / layout[0] + ny_rank_add)
-    nx_rank = int(nx / layout[1] + nx_rank_add)
+    ny_rank = int(ny / layout[1] + ny_rank_add)
+    nx_rank = int(nx / layout[0] + nx_rank_add)
     grid = fv3gfs.util.TilePartitioner(layout)
     time = cftime.DatetimeJulian(2010, 6, 20, 6, 0, 0)
     timestep = timedelta(hours=1)


### PR DESCRIPTION
I did a simulation with a non-square layout (`layout=1,2`) and the ZarrMonitor saved output with the wrong shape `(2*nx, 0.5*ny)` instead of (nx, ny). Suggests to me that the assumption in fv3gfs-util that `layout` is ordered as `y,x` is incorrect. This seems to be confirmed by the Fortran code, e.g. see [here](https://github.com/VulcanClimateModeling/fv3gfs-fortran/blob/bb932d9c4ef03d8a53954f1b2902e7f5f7126f97/FV3/atmos_cubed_sphere/tools/fv_mp_mod.F90#L384-L385). (Thanks @spencerkclark for the link).

This draft PR corrects this assumption about the layout in all the tests of fv3gfs-util.