### PR TITLE
Add NullTimer tests

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,12 @@
 History
 =======
 
+latest
+------
+
+Major changes:
+- Added NullTimer to use for default Timer value, it is a disabled timer which cannot be enabled (raises NotImplementedError)
+
 v0.6.0
 ------
 

--- a/fv3gfs/util/_timing.py
+++ b/fv3gfs/util/_timing.py
@@ -116,7 +116,7 @@ class NullTimer(Timer):
     def __init__(self):
         super().__init__()
         self._enabled = False
-    
+
     def enable(self):
         """Enable the Timer."""
         raise NotImplementedError(

--- a/fv3gfs/util/_timing.py
+++ b/fv3gfs/util/_timing.py
@@ -113,8 +113,18 @@ class NullTimer(Timer):
     Meant to be used in place of an optional timer.
     """
 
-    def start(self, name: str):
-        pass
+    def __init__(self):
+        super().__init__()
+        self._enabled = False
+    
+    def enable(self):
+        """Enable the Timer."""
+        raise NotImplementedError(
+            "NullTimer cannot be enabled, maybe create a Timer and "
+            "disable it instead of using NullTimer"
+        )
 
-    def stop(self, name: str):
-        pass
+    @property
+    def enabled(self) -> bool:
+        """Indicates whether the timer is currently enabled."""
+        return False

--- a/tests/test_timer.py
+++ b/tests/test_timer.py
@@ -1,4 +1,4 @@
-from fv3gfs.util import Timer
+from fv3gfs.util import Timer, NullTimer
 import pytest
 import time
 
@@ -7,6 +7,9 @@ import time
 def timer():
     return Timer()
 
+@pytest.fixture
+def null_timer():
+    return NullTimer()
 
 def test_start_stop(timer):
     timer.start("label")
@@ -16,6 +19,15 @@ def test_start_stop(timer):
     assert len(times) == 1
     assert timer.hits["label"] == 1
     assert len(timer.hits) == 1
+
+
+def test_null_timer_cannot_be_enabled(null_timer):
+    with pytest.raises(NotImplementedError):
+        null_timer.enable()
+
+
+def test_null_timer_is_disabled(null_timer):
+    assert not null_timer.enabled
 
 
 def test_clock(timer):

--- a/tests/test_timer.py
+++ b/tests/test_timer.py
@@ -7,9 +7,11 @@ import time
 def timer():
     return Timer()
 
+
 @pytest.fixture
 def null_timer():
     return NullTimer()
+
 
 def test_start_stop(timer):
     timer.start("label")


### PR DESCRIPTION
Added NullTimer to use for default Timer value, it is a disabled timer which cannot be enabled (raises NotImplementedError).

Also added a history entry for adding the NullTimer, since it wasn't done in the last PR.