### PR TITLE
Enable halo updates on GPU with CPU buffers

### DIFF
--- a/fv3gfs/util/buffer.py
+++ b/fv3gfs/util/buffer.py
@@ -2,7 +2,8 @@ from typing import Callable, Iterable, Optional, Dict, Tuple
 from ._timing import Timer, NullTimer
 from numpy import ndarray
 import contextlib
-from .utils import is_c_contiguous
+
+from .utils import assign_array, is_c_contiguous
 from .types import Allocator
 
 
@@ -57,7 +58,7 @@ def send_buffer(allocator: Callable, array: ndarray, timer: Optional[Timer] = No
     else:
         timer.start("pack")
         with array_buffer(allocator, array.shape, array.dtype) as sendbuf:
-            sendbuf[:] = array
+            assign_array(sendbuf, array)
             # this is a little dangerous, because if there is an exception in the two
             # lines above the timer may be started but never stopped. However, it
             # cannot be avoided because we cannot put those two lines in a with or
@@ -91,4 +92,4 @@ def recv_buffer(allocator: Callable, array: ndarray, timer: Optional[Timer] = No
             timer.stop("unpack")
             yield recvbuf
             with timer.clock("unpack"):
-                array[:] = recvbuf
+                assign_array(array, recvbuf)

--- a/fv3gfs/util/communicator.py
+++ b/fv3gfs/util/communicator.py
@@ -6,6 +6,7 @@ from .boundary import Boundary
 from .rotate import rotate_scalar_data, rotate_vector_data
 from .buffer import array_buffer, send_buffer, recv_buffer
 from ._timing import Timer
+import numpy as np
 import logging
 
 __all__ = [
@@ -66,14 +67,14 @@ class Communicator:
         return self.comm.Get_rank()
 
     def _Scatter(self, numpy, sendbuf, recvbuf, **kwargs):
-        with send_buffer(numpy.empty, sendbuf) as send, recv_buffer(
-            numpy.empty, recvbuf
+        with send_buffer(np.empty, sendbuf) as send, recv_buffer(
+            np.empty, recvbuf
         ) as recv:
             self.comm.Scatter(send, recv, **kwargs)
 
     def _Gather(self, numpy, sendbuf, recvbuf, **kwargs):
-        with send_buffer(numpy.empty, sendbuf) as send, recv_buffer(
-            numpy.empty, recvbuf
+        with send_buffer(np.empty, sendbuf) as send, recv_buffer(
+            np.empty, recvbuf
         ) as recv:
             self.comm.Gather(send, recv, **kwargs)
 
@@ -639,16 +640,16 @@ class CubedSphereCommunicator(Communicator):
         # don't want to use a buffer here, because we leave this scope and can't close
         # the context manager. might figure out a way to do it later
         with self.timer.clock("pack"):
-            array = numpy.ascontiguousarray(in_array)
+            array = np.ascontiguousarray(in_array)
         with self.timer.clock("Isend"):
             return self.comm.Isend(array, **kwargs)
 
     def _Send(self, numpy, in_array, **kwargs):
-        with send_buffer(numpy.empty, in_array, timer=self.timer) as sendbuf:
+        with send_buffer(np.empty, in_array, timer=self.timer) as sendbuf:
             self.comm.Send(sendbuf, **kwargs)
 
     def _Recv(self, numpy, out_array, **kwargs):
-        with recv_buffer(numpy.empty, out_array, timer=self.timer) as recvbuf:
+        with recv_buffer(np.empty, out_array, timer=self.timer) as recvbuf:
             with self.timer.clock("Recv"):
                 self.comm.Recv(recvbuf, **kwargs)
 
@@ -657,7 +658,7 @@ class CubedSphereCommunicator(Communicator):
         # buffer and then copy that buffer into the output array. Instead we will
         # just do a Recv() when wait is called.
         def recv():
-            with recv_buffer(numpy.empty, out_array, timer=self.timer) as recvbuf:
+            with recv_buffer(np.empty, out_array, timer=self.timer) as recvbuf:
                 with self.timer.clock("Recv"):
                     self.comm.Recv(recvbuf, **kwargs)
 

--- a/fv3gfs/util/communicator.py
+++ b/fv3gfs/util/communicator.py
@@ -85,7 +85,7 @@ class Communicator:
     ) -> Quantity:
         """Transfer subtile regions of a full-tile quantity
         from the tile root rank to all subtiles.
-        
+
         Args:
             send_quantity: quantity to send, only required/used on the tile root rank
             recv_quantity: if provided, assign received data into this Quantity.
@@ -160,7 +160,7 @@ class Communicator:
     ) -> Optional[Quantity]:
         """Transfer subtile regions of a full-tile quantity
         from each rank to the tile root rank.
-        
+
         Args:
             send_quantity: quantity to send
             recv_quantity: if provided, assign received data into this Quantity (only
@@ -236,7 +236,7 @@ class Communicator:
 
     def scatter_state(self, send_state=None, recv_state=None):
         """Transfer a state dictionary from the tile root rank to all subtiles.
-        
+
         Args:
             send_state: the model state to be sent containing the entire tile,
                 required only from the root rank
@@ -290,7 +290,7 @@ class TileCommunicator(Communicator):
 
     def __init__(self, comm, partitioner: TilePartitioner):
         """Initialize a TileCommunicator.
-        
+
         Args:
             comm: mpi4py.Comm object
             partitioner: tile partitioner
@@ -307,7 +307,7 @@ class CubedSphereCommunicator(Communicator):
 
     def __init__(self, comm, partitioner: CubedSpherePartitioner):
         """Initialize a CubedSphereCommunicator.
-        
+
         Args:
             comm: mpi4py.Comm object
             partitioner: cubed sphere partitioner
@@ -477,7 +477,7 @@ class CubedSphereCommunicator(Communicator):
         Args:
             x_quantity: the x-component quantity to be synchronized
             y_quantity: the y-component quantity to be synchronized
-        
+
         Returns:
             request: an asynchronous request object with a .wait() method
         """
@@ -640,7 +640,10 @@ class CubedSphereCommunicator(Communicator):
         # don't want to use a buffer here, because we leave this scope and can't close
         # the context manager. might figure out a way to do it later
         with self.timer.clock("pack"):
-            array = np.ascontiguousarray(in_array)
+            array = np.ascontiguousarray(
+                numpy.asnumpy(in_array) if hasattr(numpy, "asnumpy") else in_array
+            )
+
         with self.timer.clock("Isend"):
             return self.comm.Isend(array, **kwargs)
 

--- a/fv3gfs/util/testing/dummy_comm.py
+++ b/fv3gfs/util/testing/dummy_comm.py
@@ -1,6 +1,6 @@
 import logging
 import copy
-from ..utils import ensure_contiguous
+from ..utils import assign_array, ensure_contiguous
 
 
 logger = logging.getLogger("fv3gfs.util")
@@ -109,7 +109,7 @@ class DummyComm:
             sendbuf = self._get_buffer("scatter", copy.deepcopy(sendbuf))
         else:
             sendbuf = self._get_buffer("scatter", None)
-        recvbuf[:] = sendbuf[self.rank]
+        assign_array(recvbuf, sendbuf[self.rank])
 
     def Gather(self, sendbuf, recvbuf, root=0, **kwargs):
         ensure_contiguous(sendbuf)
@@ -126,7 +126,7 @@ class DummyComm:
                     f"gather called on root rank before ranks {uncalled_ranks}"
                 )
             for i, sendbuf in enumerate(gather_buffer):
-                recvbuf[i, :] = sendbuf
+                assign_array(recvbuf[i, :], sendbuf)
 
     def Send(self, sendbuf, dest, **kwargs):
         ensure_contiguous(sendbuf)
@@ -142,7 +142,7 @@ class DummyComm:
 
     def Recv(self, recvbuf, source, **kwargs):
         ensure_contiguous(recvbuf)
-        recvbuf[:] = self._get_send_recv(source)
+        assign_array(recvbuf, self._get_send_recv(source))
 
     def Irecv(self, recvbuf, source, **kwargs):
         def receive():

--- a/tests/mpi/test_mpi_halo_update.py
+++ b/tests/mpi/test_mpi_halo_update.py
@@ -245,7 +245,8 @@ def depth_quantity(
 ):
     """A quantity whose value indicates the distance from the computational
     domain boundary."""
-    data = numpy.zeros(shape, dtype=dtype) + numpy.nan
+    data = numpy.zeros(shape, dtype=dtype)
+    data[:] = numpy.nan
     for n_inside in range(max(n_points, max(extent) // 2), -1, -1):
         for i, dim in enumerate(dims):
             if (n_inside <= extent[i] // 2) and (dim in fv3gfs.util.HORIZONTAL_DIMS):


### PR DESCRIPTION
This PR enables passing halo exchange tests by introducing intermediate CPU buffers, including some `numpy` / `cupy` translation code to required to work with the managed memory storages in `gt4py`.