### PR TITLE
Fix ZarrMonitor dependence on consistent dict order

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -7,6 +7,9 @@ latest
 Major changes:
 - Added NullTimer to use for default Timer value, it is a disabled timer which cannot be enabled (raises NotImplementedError)
 
+Fixes:
+- Fixed bug where ZarrMonitor depended on dict `.items()` always returning items in the same order
+
 v0.6.0
 ------
 

--- a/fv3gfs/util/zarr_monitor.py
+++ b/fv3gfs/util/zarr_monitor.py
@@ -103,7 +103,7 @@ class ZarrMonitor:
         is "time" which is stored with dimensions [time].
         """
         self._ensure_writers_are_consistent(state)
-        for name, quantity in state.items():
+        for name, quantity in sorted(state.items(), key=lambda x: x[0]):
             self._writers[name].append(quantity)  # type: ignore[index]
 
 


### PR DESCRIPTION
Explicitly sort variables before updating them to avoid mixing variable order of bcast calls. Without this fix, manipulating the state dictionary differently on different processes can cause the bcast call when updating the zarr to pass data between different quantities on different processes.