### PR TITLE
make xarray and zarr optional dependencies, test with and without them

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
       - run:
           name: run tests
           command: |
-            tox -e test test_no_extras
+            tox -e test -e test_no_extras
 
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
       - run:
           name: run tests
           command: |
-            tox
+            tox -e test test_no_extras
 
 
 workflows:

--- a/fv3gfs/util/_legacy_restart.py
+++ b/fv3gfs/util/_legacy_restart.py
@@ -1,6 +1,6 @@
 from typing import Iterable, BinaryIO, Generator
 import os
-from . import _xarray
+from . import _xarray as xr
 import copy
 from ._properties import RestartProperties, RESTART_PROPERTIES
 from . import io, filesystem, constants
@@ -140,7 +140,7 @@ def prepend_label(filename, label=None):
 def load_partial_state_from_restart_file(
     file, restart_properties: RestartProperties, only_names=None
 ):
-    ds = _xarray.xr.open_dataset(file).isel(Time=0).drop_vars("Time")
+    ds = xr.open_dataset(file).isel(Time=0).drop_vars("Time")
     state = map_keys(ds.data_vars, _get_restart_standard_names(restart_properties))
     state = _apply_restart_metadata(state, restart_properties)
     if only_names is None:

--- a/fv3gfs/util/_legacy_restart.py
+++ b/fv3gfs/util/_legacy_restart.py
@@ -1,6 +1,6 @@
 from typing import Iterable, BinaryIO, Generator
 import os
-import xarray as xr
+from . import _xarray
 import copy
 from ._properties import RestartProperties, RESTART_PROPERTIES
 from . import io, filesystem, constants
@@ -140,7 +140,7 @@ def prepend_label(filename, label=None):
 def load_partial_state_from_restart_file(
     file, restart_properties: RestartProperties, only_names=None
 ):
-    ds = xr.open_dataset(file).isel(Time=0).drop_vars("Time")
+    ds = _xarray.xr.open_dataset(file).isel(Time=0).drop_vars("Time")
     state = map_keys(ds.data_vars, _get_restart_standard_names(restart_properties))
     state = _apply_restart_metadata(state, restart_properties)
     if only_names is None:

--- a/fv3gfs/util/_optional_imports.py
+++ b/fv3gfs/util/_optional_imports.py
@@ -1,11 +1,9 @@
-
 class RaiseWhenAccessed:
-
     def __init__(self, err):
         self._err = err
-    
+
     def __getattr__(self, _):
         raise self._err
-    
+
     def __call__(self, *args, **kwargs):
         raise self._err

--- a/fv3gfs/util/_optional_imports.py
+++ b/fv3gfs/util/_optional_imports.py
@@ -1,0 +1,11 @@
+
+class RaiseWhenAccessed:
+
+    def __init__(self, err):
+        self._err = err
+    
+    def __getattr__(self, _):
+        raise self._err
+    
+    def __call__(self, *args, **kwargs):
+        raise self._err

--- a/fv3gfs/util/_xarray.py
+++ b/fv3gfs/util/_xarray.py
@@ -3,6 +3,7 @@ try:
     from xarray import DataArray
 except ModuleNotFoundError as err:
     from ._optional_imports import RaiseWhenAccessed
+
     xr = RaiseWhenAccessed(err)
     DataArray = RaiseWhenAccessed(err)
 

--- a/fv3gfs/util/_xarray.py
+++ b/fv3gfs/util/_xarray.py
@@ -8,6 +8,10 @@ except ModuleNotFoundError as err:
     DataArray = RaiseWhenAccessed(err)
 
 
+def open_dataset(*args, **kwargs):
+    return xr.open_dataset(*args, **kwargs)
+
+
 def to_dataset(state):
     data_vars = {
         name: value.data_array for name, value in state.items() if name != "time"

--- a/fv3gfs/util/_xarray.py
+++ b/fv3gfs/util/_xarray.py
@@ -1,6 +1,10 @@
-import xarray as xr
-
-__all__ = ["to_dataset"]
+try:
+    import xarray as xr
+    from xarray import DataArray
+except ModuleNotFoundError as err:
+    from ._optional_imports import RaiseWhenAccessed
+    xr = RaiseWhenAccessed(err)
+    DataArray = RaiseWhenAccessed(err)
 
 
 def to_dataset(state):

--- a/fv3gfs/util/io.py
+++ b/fv3gfs/util/io.py
@@ -1,10 +1,9 @@
 import cftime
-from . import _xarray
+from . import _xarray as xr
 from typing import TextIO
 from .time import FMS_TO_CFTIME_TYPE
 from . import filesystem
 from .quantity import Quantity
-from ._xarray import to_dataset
 
 
 def write_state(state: dict, filename: str) -> None:
@@ -16,12 +15,12 @@ def write_state(state: dict, filename: str) -> None:
     """
     if "time" not in state:
         raise ValueError('state must include a value for "time"')
-    ds = to_dataset(state)
+    ds = xr.to_dataset(state)
     with filesystem.open(filename, "wb") as f:
         ds.to_netcdf(f)
 
 
-def _extract_time(value: _xarray.DataArray) -> cftime.datetime:
+def _extract_time(value: xr.DataArray) -> cftime.datetime:
     """Exctract time value from read-in state."""
     if value.ndim > 0:
         raise ValueError(
@@ -47,7 +46,7 @@ def read_state(filename: str) -> dict:
     """
     out_dict = {}
     with filesystem.open(filename, "rb") as f:
-        ds = _xarray.xr.open_dataset(f, use_cftime=True)
+        ds = xr.open_dataset(f, use_cftime=True)
         for name, value in ds.data_vars.items():
             if name == "time":
                 out_dict[name] = _extract_time(value)

--- a/fv3gfs/util/io.py
+++ b/fv3gfs/util/io.py
@@ -1,5 +1,5 @@
 import cftime
-import xarray as xr
+from . import _xarray
 from typing import TextIO
 from .time import FMS_TO_CFTIME_TYPE
 from . import filesystem
@@ -21,7 +21,7 @@ def write_state(state: dict, filename: str) -> None:
         ds.to_netcdf(f)
 
 
-def _extract_time(value: xr.DataArray) -> cftime.datetime:
+def _extract_time(value: _xarray.DataArray) -> cftime.datetime:
     """Exctract time value from read-in state."""
     if value.ndim > 0:
         raise ValueError(
@@ -47,7 +47,7 @@ def read_state(filename: str) -> dict:
     """
     out_dict = {}
     with filesystem.open(filename, "rb") as f:
-        ds = xr.open_dataset(f, use_cftime=True)
+        ds = _xarray.xr.open_dataset(f, use_cftime=True)
         for name, value in ds.data_vars.items():
             if name == "time":
                 out_dict[name] = _extract_time(value)

--- a/fv3gfs/util/quantity.py
+++ b/fv3gfs/util/quantity.py
@@ -2,7 +2,7 @@ from typing import Tuple, Iterable, Dict, Union, Sequence, cast
 import warnings
 import dataclasses
 import numpy as np
-import xarray as xr
+from . import _xarray
 from ._boundary_utils import shift_boundary_slice_tuple, bound_default_slice
 from . import constants
 from .types import NumpyModule
@@ -329,7 +329,7 @@ class Quantity:
     @classmethod
     def from_data_array(
         cls,
-        data_array: xr.DataArray,
+        data_array: _xarray.DataArray,
         origin: Sequence[int] = None,
         extent: Sequence[int] = None,
         gt4py_backend: Union[str, None] = None,
@@ -467,8 +467,8 @@ class Quantity:
         return self.metadata.extent
 
     @property
-    def data_array(self) -> xr.DataArray:
-        return xr.DataArray(self.view[:], dims=self.dims, attrs=self.attrs)
+    def data_array(self) -> _xarray.DataArray:
+        return _xarray.DataArray(self.view[:], dims=self.dims, attrs=self.attrs)
 
     @property
     def np(self) -> NumpyModule:

--- a/fv3gfs/util/zarr_monitor.py
+++ b/fv3gfs/util/zarr_monitor.py
@@ -1,9 +1,13 @@
 from typing import Union, Tuple
 import cftime
 import logging
-import zarr
+try:
+    import zarr
+except ModuleNotFoundError as err:
+    from ._optional_imports import RaiseWhenAccessed
+    zarr = RaiseWhenAccessed(err)
 import numpy as np
-import xarray as xr
+from . import _xarray
 from . import constants, utils
 from .partitioner import CubedSpherePartitioner, subtile_slice
 
@@ -39,7 +43,7 @@ class ZarrMonitor:
 
     def __init__(
         self,
-        store: Union[str, zarr.storage.MutableMapping],
+        store: Union[str, "zarr.storage.MutableMapping"],
         partitioner: CubedSpherePartitioner,
         mode: str = "w",
         mpi_comm=DummyComm(),
@@ -273,7 +277,7 @@ class _ZarrTimeWriter(_ZarrVariableWriter):
         )
 
     def append(self, time):
-        array = xr.DataArray()
+        array = _xarray.DataArray()
         if self.array is None:
             self._init_zarr(array)
             self._set_time_encoding_attrs(time)

--- a/fv3gfs/util/zarr_monitor.py
+++ b/fv3gfs/util/zarr_monitor.py
@@ -1,10 +1,12 @@
 from typing import Union, Tuple
 import cftime
 import logging
+
 try:
     import zarr
 except ModuleNotFoundError as err:
     from ._optional_imports import RaiseWhenAccessed
+
     zarr = RaiseWhenAccessed(err)
 import numpy as np
 from . import _xarray

--- a/fv3gfs/util/zarr_monitor.py
+++ b/fv3gfs/util/zarr_monitor.py
@@ -9,7 +9,7 @@ except ModuleNotFoundError as err:
 
     zarr = RaiseWhenAccessed(err)
 import numpy as np
-from . import _xarray
+from . import _xarray as xr
 from . import constants, utils
 from .partitioner import CubedSpherePartitioner, subtile_slice
 
@@ -279,7 +279,7 @@ class _ZarrTimeWriter(_ZarrVariableWriter):
         )
 
     def append(self, time):
-        array = _xarray.DataArray()
+        array = xr.DataArray()
         if self.array is None:
             self._init_zarr(array)
             self._set_time_encoding_attrs(time)

--- a/setup.py
+++ b/setup.py
@@ -5,12 +5,9 @@ setup_requirements = []
 
 requirements = [
     "cftime>=1.2.1",
-    "xarray>=0.15.1",
     "numpy>=0.15.0",
     "fsspec>=0.6.0",
-    "zarr>=2.3.2",
     "typing_extensions>=3.7.4",
-    "scipy>=1.3.1",
 ]
 if sys.version_info.major == 3 and sys.version_info.minor == 6:
     requirements.append("dataclasses")
@@ -41,6 +38,10 @@ setup(
     install_requires=requirements,
     setup_requires=setup_requirements,
     tests_require=test_requirements,
+    extras_require={
+        "netcdf": ["xarray>=0.15.1", "scipy>=1.3.1"],
+        "zarr": ["zarr>=2.3.2", "xarray>=0.15.1", "scipy>=1.3.1"],
+    },
     name="fv3gfs-util",
     license="BSD license",
     long_description=readme + "\n\n" + history,

--- a/tests/quantity/test_quantity.py
+++ b/tests/quantity/test_quantity.py
@@ -2,6 +2,12 @@ import pytest
 import numpy as np
 import fv3gfs.util
 import fv3gfs.util.quantity
+try:
+    import xarray as xr
+except ModuleNotFoundError:
+    xr = None
+
+requires_xarray = pytest.mark.skipif(xr is None, reason="xarray is not installed")
 
 
 @pytest.fixture(params=["empty", "one", "five"])
@@ -213,6 +219,7 @@ def test_shift_slice(slice_in, shift, extent, slice_out):
         ),
     ],
 )
+@requires_xarray
 def test_to_data_array(quantity):
     assert quantity.data_array.attrs == quantity.attrs
     assert quantity.data_array.dims == quantity.dims

--- a/tests/quantity/test_quantity.py
+++ b/tests/quantity/test_quantity.py
@@ -2,6 +2,7 @@ import pytest
 import numpy as np
 import fv3gfs.util
 import fv3gfs.util.quantity
+
 try:
     import xarray as xr
 except ModuleNotFoundError:

--- a/tests/test_legacy_restart.py
+++ b/tests/test_legacy_restart.py
@@ -1,12 +1,17 @@
 import os
 import tempfile
 import cftime
-import xarray as xr
+try:
+    import xarray as xr
+except ModuleNotFoundError:
+    xr = None
 import numpy as np
 import pytest
 import fv3gfs.util
 import fv3gfs.util._legacy_restart
 from fv3gfs.util.testing import DummyComm
+
+requires_xarray = pytest.mark.skipif(xr is None, reason="xarray is not installed")
 
 TEST_DIRECTORY = os.path.dirname(os.path.realpath(__file__))
 DATA_DIRECTORY = os.path.join(TEST_DIRECTORY, "data")
@@ -17,6 +22,7 @@ def layout(request):
     return request.param
 
 
+@requires_xarray
 def get_c12_restart_state_list(layout, only_names, tracer_properties):
     total_ranks = layout[0] * layout[1]
     shared_buffer = {}
@@ -42,6 +48,7 @@ def get_c12_restart_state_list(layout, only_names, tracer_properties):
 
 @pytest.mark.parametrize("layout", [(1, 1), (3, 3)])
 @pytest.mark.cpu_only
+@requires_xarray
 def test_open_c12_restart(layout):
     tracer_properties = {}
     only_names = None
@@ -109,6 +116,7 @@ def test_open_c12_restart(layout):
         },
     ],
 )
+@requires_xarray
 @pytest.mark.cpu_only
 def test_open_c12_restart_tracer_properties(layout, tracer_properties):
     only_names = None
@@ -125,6 +133,7 @@ def test_open_c12_restart_tracer_properties(layout, tracer_properties):
 
 @pytest.mark.parametrize("layout", [(1, 1), (3, 3)])
 @pytest.mark.cpu_only
+@requires_xarray
 def test_open_c12_restart_empty_to_state_without_crashing(layout):
     total_ranks = layout[0] * layout[1]
     ny = 12 / layout[0]
@@ -167,6 +176,7 @@ def test_open_c12_restart_empty_to_state_without_crashing(layout):
 
 @pytest.mark.parametrize("layout", [(1, 1), (3, 3)])
 @pytest.mark.cpu_only
+@requires_xarray
 def test_open_c12_restart_to_allocated_state_without_crashing(layout):
     total_ranks = layout[0] * layout[1]
     ny = 12 / layout[0]
@@ -263,6 +273,7 @@ def result_dims(data_array, new_dims):
 
 
 @pytest.mark.cpu_only
+@requires_xarray
 def test_apply_dims(data_array, new_dims, result_dims):
     result = fv3gfs.util._legacy_restart._apply_dims(data_array, new_dims)
     np.testing.assert_array_equal(result.values, data_array.values)
@@ -327,6 +338,7 @@ def test_get_rank_suffix_invalid_total_ranks(invalid_total_ranks):
 
 
 @pytest.mark.cpu_only
+@requires_xarray
 def test_read_state_incorrectly_encoded_time():
     with tempfile.NamedTemporaryFile(mode="w", suffix=".nc") as file:
         state_ds = xr.DataArray(0.0, name="time").to_dataset()
@@ -336,6 +348,7 @@ def test_read_state_incorrectly_encoded_time():
 
 
 @pytest.mark.cpu_only
+@requires_xarray
 def test_read_state_non_scalar_time():
     with tempfile.NamedTemporaryFile(mode="w", suffix=".nc") as file:
         state_ds = xr.DataArray([0.0, 1.0], dims=["T"], name="time").to_dataset()
@@ -349,6 +362,7 @@ def test_read_state_non_scalar_time():
     [["time", "air_temperature"], ["air_temperature"]],
     ids=lambda x: f"{x}",
 )
+@requires_xarray
 def test_open_c12_restart_only_names(layout, only_names):
     tracer_properties = {}
     c12_restart_state_list = get_c12_restart_state_list(

--- a/tests/test_legacy_restart.py
+++ b/tests/test_legacy_restart.py
@@ -1,6 +1,7 @@
 import os
 import tempfile
 import cftime
+
 try:
     import xarray as xr
 except ModuleNotFoundError:

--- a/tests/test_zarr_monitor.py
+++ b/tests/test_zarr_monitor.py
@@ -1,14 +1,21 @@
 import tempfile
-import zarr
+try:
+    import zarr
+except ModuleNotFoundError:
+    zarr = None
 import cftime
 from datetime import timedelta
 import pytest
-import xarray as xr
+try:
+    import xarray as xr
+except ModuleNotFoundError:
+    xr = None
 import copy
 import fv3gfs.util
 import logging
 from fv3gfs.util.testing import DummyComm
 
+requires_zarr = pytest.mark.skipif(zarr is None, reason="zarr is not installed")
 
 logger = logging.getLogger("test_zarr_monitor")
 
@@ -108,6 +115,7 @@ def state_list(base_state, n_times, start_time, time_step, numpy):
     return state_list
 
 
+@requires_zarr
 def test_monitor_file_store(state_list, cube_partitioner, numpy, start_time):
     with tempfile.TemporaryDirectory(suffix=".zarr") as tempdir:
         monitor = fv3gfs.util.ZarrMonitor(tempdir, cube_partitioner)
@@ -117,11 +125,13 @@ def test_monitor_file_store(state_list, cube_partitioner, numpy, start_time):
         validate_xarray_can_open(tempdir)
 
 
+@requires_zarr
 def validate_xarray_can_open(dirname):
     # just checking there are no crashes, validate_group checks data
     xr.open_zarr(dirname)
 
 
+@requires_zarr
 def validate_store(states, filename, numpy, start_time):
     nt = len(states)
     calendar = start_time.calendar
@@ -183,6 +193,7 @@ def validate_store(states, filename, numpy, start_time):
         ((5, 4, 4), 0, 1, ("z", "y", "x_interface")),
     ],
 )
+@requires_zarr
 def test_monitor_file_store_multi_rank_state(
     layout, nt, tmpdir_factory, shape, ny_rank_add, nx_rank_add, dims, numpy
 ):
@@ -283,12 +294,13 @@ def test_monitor_file_store_multi_rank_state(
         ),
     ],
 )
+@requires_zarr
 def test_array_chunks(layout, tile_array_shape, array_dims, target):
     result = fv3gfs.util.zarr_monitor.array_chunks(layout, tile_array_shape, array_dims)
     assert result == target
 
 
-def _assert_no_nulls(dataset: xr.Dataset):
+def _assert_no_nulls(dataset: "xr.Dataset"):
     number_of_null = dataset["var"].isnull().sum().item()
     total_size = dataset["var"].size
 
@@ -298,6 +310,7 @@ def _assert_no_nulls(dataset: xr.Dataset):
 
 
 @pytest.mark.parametrize("mask_and_scale", [True, False])
+@requires_zarr
 def test_open_zarr_without_nans(cube_partitioner, numpy, backend, mask_and_scale):
 
     store = {}
@@ -314,6 +327,7 @@ def test_open_zarr_without_nans(cube_partitioner, numpy, backend, mask_and_scale
     _assert_no_nulls(dataset.sel(tile=0))
 
 
+@requires_zarr
 def test_values_preserved(cube_partitioner, numpy):
     dims = ("y", "x")
     units = "m"
@@ -350,6 +364,7 @@ def state_list_with_inconsistent_calendars(base_state, numpy):
     return state_list
 
 
+@requires_zarr
 def test_monitor_file_store_inconsistent_calendars(
     state_list_with_inconsistent_calendars, cube_partitioner, numpy
 ):

--- a/tests/test_zarr_monitor.py
+++ b/tests/test_zarr_monitor.py
@@ -1,4 +1,5 @@
 import tempfile
+
 try:
     import zarr
 except ModuleNotFoundError:
@@ -6,6 +7,7 @@ except ModuleNotFoundError:
 import cftime
 from datetime import timedelta
 import pytest
+
 try:
     import xarray as xr
 except ModuleNotFoundError:

--- a/tox.ini
+++ b/tox.ini
@@ -7,18 +7,19 @@
 envlist = py3
 
 [testenv:test_no_extras]
-allowlist_externals=make mpirun
+allowlist_externals=make
 deps =
     # other versions of pytest don't work with subtests
     pytest == 5.2.2
     pytest-subtests==0.3.0
     pytest-cov==2.8.1
     git+https://github.com/GridTools/gt4py.git@db40777788863bfe87b9674b118e8bd5b8db0440#egg=gt4py
-    mpi4py==3.0.3
+# only run a subset of tests (fast, no MPI tests)
+# to check import infrastructure works with no extras
 setenv =
     PYTEST_ARGS = --fast
 commands =
-    make test test_mpi
+    make test
 
 
 [testenv:test]

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@
 [tox]
 envlist = py3
 
-[testenv]
+[testenv:test_no_extras]
 allowlist_externals=make mpirun
 deps =
     # other versions of pytest don't work with subtests
@@ -15,6 +15,22 @@ deps =
     pytest-cov==2.8.1
     git+https://github.com/GridTools/gt4py.git@db40777788863bfe87b9674b118e8bd5b8db0440#egg=gt4py
     mpi4py==3.0.3
+setenv =
+    PYTEST_ARGS = --fast
+commands =
+    make test test_mpi
+
+
+[testenv:test]
+allowlist_externals=make mpirun
+deps =
+    # other versions of pytest don't work with subtests
+    pytest == 5.2.2
+    pytest-subtests==0.3.0
+    pytest-cov==2.8.1
+    git+https://github.com/GridTools/gt4py.git@db40777788863bfe87b9674b118e8bd5b8db0440#egg=gt4py
+    mpi4py==3.0.3
+extras = netcdf,zarr
 commands =
     make test test_mpi
 


### PR DESCRIPTION
In testing fv3core on HPC, we are constrained in the number of files we can put on the filesystem. Most of these files are python files in our runtime environment. Making xarray and zarr optional dependencies will allow us to test fv3core on HPC without them, reducing our file count.