### PR TITLE
Synchronize upfront of all halo exchange

### DIFF
--- a/fv3gfs/util/buffer.py
+++ b/fv3gfs/util/buffer.py
@@ -68,7 +68,7 @@ class Buffer:
 
     def finalize_memory_transfer(self):
         """Finalize any memory transfer"""
-        device_synchronize(self.array)
+        device_synchronize()
 
     def assign_to(
         self,

--- a/fv3gfs/util/communicator.py
+++ b/fv3gfs/util/communicator.py
@@ -455,6 +455,7 @@ class CubedSphereCommunicator(Communicator):
     @staticmethod
     def _device_synchronize():
         """Wait for all work that could be in-flight to finish."""
+        # this is a method so we can profile it separately from other device syncs
         device_synchronize()
 
     def start_halo_update(self, quantity: Quantity, n_points: int) -> HaloUpdateRequest:

--- a/fv3gfs/util/communicator.py
+++ b/fv3gfs/util/communicator.py
@@ -452,9 +452,10 @@ class CubedSphereCommunicator(Communicator):
         req = self.start_halo_update(quantity, n_points)
         req.wait()
 
-    def _synchronize(self):
+    @staticmethod
+    def _device_synchronize(self):
         """Wait for all work that could be in-flight to finish."""
-        device_synchronize(None)
+        device_synchronize()
 
     def start_halo_update(self, quantity: Quantity, n_points: int) -> HaloUpdateRequest:
         """Start an asynchronous halo update on a quantity.
@@ -468,7 +469,7 @@ class CubedSphereCommunicator(Communicator):
         """
         if n_points == 0:
             raise ValueError("cannot perform a halo update on zero halo points")
-        self._synchronize()
+        CubedSphereCommunicator._device_synchronize()
         tag = self._get_halo_tag()
         recv_data = self._Irecv_halos(quantity, n_points, tag=tag)
         send_data = self._Isend_halos(quantity, n_points, tag=tag)
@@ -570,7 +571,7 @@ class CubedSphereCommunicator(Communicator):
         """
         if not on_c_grid(x_quantity, y_quantity):
             raise ValueError("vector must be defined on Arakawa C-grid")
-        self._synchronize()
+        CubedSphereCommunicator._device_synchronize()
         tag = self._get_halo_tag()
         send_requests = self._Isend_vector_shared_boundary(
             x_quantity, y_quantity, tag=tag
@@ -616,7 +617,7 @@ class CubedSphereCommunicator(Communicator):
         """
         if n_points == 0:
             raise ValueError("cannot perform a halo update on zero halo points")
-        self._synchronize()
+        CubedSphereCommunicator._device_synchronize()
         tag1, tag2 = self._get_halo_tag(), self._get_halo_tag()
         send_data: _HaloRequestSendList = self._Isend_vector_halos(
             x_quantity, y_quantity, n_points, tags=(tag1, tag2)

--- a/fv3gfs/util/communicator.py
+++ b/fv3gfs/util/communicator.py
@@ -453,7 +453,7 @@ class CubedSphereCommunicator(Communicator):
         req.wait()
 
     @staticmethod
-    def _device_synchronize(self):
+    def _device_synchronize():
         """Wait for all work that could be in-flight to finish."""
         device_synchronize()
 

--- a/fv3gfs/util/communicator.py
+++ b/fv3gfs/util/communicator.py
@@ -7,6 +7,7 @@ from .rotate import rotate_scalar_data, rotate_vector_data
 from .buffer import array_buffer, send_buffer, recv_buffer, Buffer
 from ._timing import Timer, NullTimer
 from .types import AsyncRequest, NumpyModule
+from .utils import device_synchronize
 import logging
 import numpy as np
 
@@ -451,6 +452,10 @@ class CubedSphereCommunicator(Communicator):
         req = self.start_halo_update(quantity, n_points)
         req.wait()
 
+    def _synchronize(self):
+        """Wait for all work that could be in-flight to finish."""
+        device_synchronize(None)
+
     def start_halo_update(self, quantity: Quantity, n_points: int) -> HaloUpdateRequest:
         """Start an asynchronous halo update on a quantity.
 
@@ -463,6 +468,7 @@ class CubedSphereCommunicator(Communicator):
         """
         if n_points == 0:
             raise ValueError("cannot perform a halo update on zero halo points")
+        self._synchronize()
         tag = self._get_halo_tag()
         recv_data = self._Irecv_halos(quantity, n_points, tag=tag)
         send_data = self._Isend_halos(quantity, n_points, tag=tag)
@@ -564,6 +570,7 @@ class CubedSphereCommunicator(Communicator):
         """
         if not on_c_grid(x_quantity, y_quantity):
             raise ValueError("vector must be defined on Arakawa C-grid")
+        self._synchronize()
         tag = self._get_halo_tag()
         send_requests = self._Isend_vector_shared_boundary(
             x_quantity, y_quantity, tag=tag
@@ -609,6 +616,7 @@ class CubedSphereCommunicator(Communicator):
         """
         if n_points == 0:
             raise ValueError("cannot perform a halo update on zero halo points")
+        self._synchronize()
         tag1, tag2 = self._get_halo_tag(), self._get_halo_tag()
         send_data: _HaloRequestSendList = self._Isend_vector_halos(
             x_quantity, y_quantity, n_points, tags=(tag1, tag2)

--- a/fv3gfs/util/utils.py
+++ b/fv3gfs/util/utils.py
@@ -1,4 +1,4 @@
-from typing import Union, Sequence, TypeVar, Tuple, Iterable
+from typing import Union, Sequence, TypeVar, Tuple, Iterable, Optional
 from .types import Allocator
 from . import constants
 import numpy as np
@@ -80,9 +80,9 @@ def safe_assign_array(
             raise
 
 
-def device_synchronize(array: Union[np.ndarray, Storage]):
+def device_synchronize(array: Optional[Union[np.ndarray, Storage]]):
     """Synchronize all memory communication"""
-    if cp and isinstance(array, cp.ndarray):
+    if cp and (array is None or isinstance(array, cp.ndarray)):
         cp.cuda.runtime.deviceSynchronize()
 
 

--- a/fv3gfs/util/utils.py
+++ b/fv3gfs/util/utils.py
@@ -1,4 +1,4 @@
-from typing import Union, Sequence, TypeVar, Tuple, Iterable, Optional
+from typing import Union, Sequence, TypeVar, Tuple, Iterable
 from .types import Allocator
 from . import constants
 import numpy as np
@@ -80,9 +80,9 @@ def safe_assign_array(
             raise
 
 
-def device_synchronize(array: Optional[Union[np.ndarray, Storage]]):
+def device_synchronize():
     """Synchronize all memory communication"""
-    if cp and (array is None or isinstance(array, cp.ndarray)):
+    if cp:
         cp.cuda.runtime.deviceSynchronize()
 
 


### PR DESCRIPTION
### Purpose

Allows for accurate calculation of halo exchange times at the cost of one extra API call.
That one extra API call can be considered minor since it is going to happen downstream at `finalize_buffer_transfer` anyway to prevent a race condition with MPI internals.

Will be obsolete when going to streaming.

### Code changes:
* Extend `device_synchronize` to sync with no array
* Wrap the upfront `device_synchronize` in a function (`_synchronize`) to track during performance measure

### Checklist

Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at Code Review Checklist.
- [x] Docstrings and type hints are added to new and updated routines, as appropriate
- [x]  All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
